### PR TITLE
FT: Redis client datastore wrapper and setup

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -58,14 +58,35 @@ class Config {
             }
         }
 
+        // default to standalone configuration
         this.redis = { host: '127.0.0.1', port: 6379 };
         if (config.redis) {
-            assert(typeof config.redis.host === 'string',
-                'bad config: redis.host must be a string');
-            assert(typeof config.redis.port === 'number',
-                'bad config: redis.port must be a number');
-            this.redis.host = config.redis.host;
-            this.redis.port = config.redis.port;
+            if (config.redis.sentinels) {
+                this.redis = { sentinels: [], name: null };
+
+                assert(typeof config.redis.name === 'string',
+                    'bad config: sentinel name must be a string');
+                this.redis.name = config.redis.name;
+
+                assert(Array.isArray(config.redis.sentinels),
+                    'bad config: sentinels must be an array');
+                config.redis.sentinels.forEach(item => {
+                    const { host, port } = item;
+                    assert(typeof host === 'string',
+                        'bad config: sentinel host must be a string');
+                    assert(typeof port === 'number',
+                        'bad config: sentinel port must be a number');
+                    this.redis.sentinels.push({ host, port });
+                });
+            } else {
+                // check for standalone configuration
+                assert(typeof config.redis.host === 'string',
+                    'bad config: redis.host must be a string');
+                assert(typeof config.redis.port === 'number',
+                    'bad config: redis.port must be a number');
+                this.redis.host = config.redis.host;
+                this.redis.port = config.redis.port;
+            }
         }
 
         if (config.certFilePaths) {

--- a/lib/Datastore.js
+++ b/lib/Datastore.js
@@ -1,0 +1,107 @@
+/* Provides methods for operations on a datastore */
+export default class Datastore {
+    /**
+    * @constructor
+    */
+    constructor() {
+        this._client = null;
+    }
+
+    /**
+    * set client, enables switching between different backends
+    * @param {object} client - client providing interface to the datastore
+    * @return {undefined}
+    */
+    setClient(client) {
+        this._client = client;
+        return this;
+    }
+
+    /**
+    * retrieve client object containing backend interfaces
+    * @return {object} client - client providing interface to the datastore
+    */
+    getClient() {
+        return this._client;
+    }
+
+    /**
+    * set key to hold the string value
+    * @param {string} key - key holding the value
+    * @param {string} value - value containing the data
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    set(key, value, cb) {
+        return this._client.set(key, value, cb);
+    }
+
+    /**
+    * get value from a key
+    * @param {string} key - key holding the value
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    get(key, cb) {
+        return this._client.get(key, cb);
+    }
+
+    /**
+    * increment value of a key by 1
+    * @param {string} key - key holding the value
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    incr(key, cb) {
+        return this._client.incr(key, cb);
+    }
+
+    /**
+    * set value of a key in a sorted set with a score
+    * @param {string} key - key holding the value
+    * @param {number} score - integer score for the key in the sorted set
+    * @param {string} value - value containing the data
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    zadd(key, score, value, cb) {
+        return this._client.zadd(key, score, value, cb);
+    }
+
+    /**
+    * get a list of results containing values whose keys fall within the
+    * min and max scores
+    * @param {string} key - key holding the value
+    * @param {number} min - integer score for start range (inclusive)
+    * @param {number} max - integer score for end range (inclusive)
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    zrangebyscore(key, min, max, cb) {
+        return this._client.zrangebyscore(key, min, max, cb);
+    }
+
+    /**
+    * batch get a list of results containing values whose keys fall within the
+    * min and max scores
+    * @param {string[]} keys - list of keys
+    * @param {number} min - integer score for start range (inclusive)
+    * @param {number} max - integer score for end range (inclusive)
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    bZrangebyscore(keys, min, max, cb) {
+        return this._client.pipeline(keys.map(
+            item => ['zrangebyscore', item, min, max])).exec(cb);
+    }
+
+    /**
+    * execute a batch of commands
+    * @param {string[]} cmds - list of commands
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    batch(cmds, cb) {
+        return this._client.batch(cmds).exec(cb);
+    }
+}

--- a/lib/UtapiRequest.js
+++ b/lib/UtapiRequest.js
@@ -12,6 +12,7 @@ export default class UtapiRequest {
         this._response = null;
         this._route = null;
         this._statusCode = 0;
+        this._datastore = null;
     }
 
     /**
@@ -27,7 +28,7 @@ export default class UtapiRequest {
      * Function to set the logger
      *
      * @param {object} log - Logger
-     * @return {VaultRequest} Current instance
+     * @return {UtapiRequest} itself
      */
     setLog(log) {
         this._log = log;
@@ -47,7 +48,7 @@ export default class UtapiRequest {
      * Function to set the validator
      *
      * @param {Validator} validator - Validator
-     * @return {VaultRequest} Current instance
+     * @return {UtapiRequest} itself
      */
     setValidator(validator) {
         this._validator = validator;
@@ -58,7 +59,7 @@ export default class UtapiRequest {
      * Set http request object
      *
      * @param {object} req - Http request object
-     * @return {VaultRequest} Current instance
+     * @return {UtapiRequest} itself
      */
     setRequest(req) {
         this._request = req;
@@ -78,7 +79,7 @@ export default class UtapiRequest {
      * Set http response object
      *
      * @param {object} res - Http response object
-     * @return {VaultRequest} Current instance
+     * @return {UtapiRequest} itself
      */
     setResponse(res) {
         this._response = res;
@@ -107,7 +108,7 @@ export default class UtapiRequest {
      * Set the current route
      *
      * @param {Route} route - Current route
-     * @return {VaultRequest} itself
+     * @return {UtapiRequest} itself
      */
     setRoute(route) {
         this._route = route;
@@ -127,11 +128,29 @@ export default class UtapiRequest {
      * Set the status code of the request
      *
      * @param {number} code - Http status code of the request
-     * @return {VaultRequest} itself
+     * @return {UtapiRequest} itself
      */
     setStatusCode(code) {
         this._statusCode = code;
         return this;
+    }
+
+    /**
+     * Set the datastore to be used as backend
+     * @param {Datastore} ds - Datastore instance
+     * @return {UtapiRequest} itself
+     */
+    setDatastore(ds) {
+        this._datastore = ds;
+        return this;
+    }
+
+    /**
+     * Get the datastore to be used as backend
+     * @return {Datastore} Datastore instance
+     */
+    getDatastore() {
+        return this._datastore;
     }
 
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,24 +1,32 @@
 import http from 'http';
 import https from 'https';
+import Redis from 'ioredis';
+
 import { Clustering, https as arsenal } from 'arsenal';
+import { Logger } from 'werelogs';
 
 import logger from '../utils/logger';
-import _config from './Config';
+import Config from './Config';
 import routes from '../router/routes';
 import Route from '../router/Route';
 import Router from '../router/Router';
 import UtapiRequest from '../lib/UtapiRequest';
+import Datastore from './Datastore';
 
 class UtapiServer {
     /**
      * This represents UtapiServer
      * @constructor
      * @param {Worker} [worker=null] - Track the worker when using cluster
+     * @param {Datasore} datastore - DataStore instance
+     * @param {Werelogs} logger - Werelogs logger instance
      */
-    constructor(worker) {
+    constructor(worker, datastore, logger) {
         this.worker = worker;
 
         this.router = new Router();
+        this.logger = logger;
+        this.server = null;
         // setup routes
         routes.forEach(item => this.router.addRoute(new Route(item)));
     }
@@ -29,7 +37,8 @@ class UtapiServer {
         const utapiRequest = new UtapiRequest()
             .setRequest(req)
             .setLog(logger.newRequestLogger())
-            .setResponse(res);
+            .setResponse(res)
+            .setDatastore(this.datastore);
         router.doRoute(utapiRequest, (err, data) => {
             if (err) {
                 return this.errorResponse(utapiRequest, err);
@@ -42,11 +51,11 @@ class UtapiServer {
      * This starts the http server.
      */
     startup() {
-        if (_config.https) {
+        if (Config.https) {
             this.server = https.createServer({
-                cert: _config.https.cert,
-                key: _config.https.key,
-                ca: _config.https.ca,
+                cert: Config.https.cert,
+                key: Config.https.key,
+                ca: Config.https.ca,
                 ciphers: arsenal.https.ciphers.ciphers,
                 dhparam: arsenal.https.dhparam.dhparam,
                 rejectUnauthorized: true,
@@ -58,16 +67,16 @@ class UtapiServer {
         this.server.on('listening', () => {
             const addr = this.server.address() || {
                 address: '0.0.0.0',
-                port: _config.port,
+                port: Config.port,
             };
-            logger.info('server started', {
+            this.logger.trace('server started', {
                 address: addr.address,
                 port: addr.port,
                 pid: process.pid,
-                https: _config.https === true,
+                https: Config.https === true,
             });
         });
-        this.server.listen(_config.port);
+        this.server.listen(Config.port);
     }
 
     /*
@@ -137,13 +146,47 @@ class UtapiServer {
 
 /**
 * Spawns a new server
+* @param {object} [params] - configuration params (optional)
+* @property {object} params.redis - redis configuration
+* @property {number} params.workers - number of workers for Cluster
+* @property {object} params.log - logger configuration
 * @return {undefined}
 */
-export default function spawn() {
-    const workers = _config.workers || 1;
+export default function spawn(params) {
+    let redis;
+    let workers;
+    let log;
+    if (params && params.redis) {
+        redis = params.redis;
+    } else {
+        redis = Config.redis;
+    }
+    if (params && params.workers) {
+        workers = params.workers;
+    } else {
+        workers = Config.workers;
+    }
+    if (params && params.log) {
+        log = params.log;
+    } else {
+        log = Config.log;
+    }
+    // when redis server is unavailable, commands are added to an offline queue
+    // and processed when redis is back again
+    // TODO: need to revisit this. It needs to be verified if this option
+    // is hogging memory under heavy load when redis is unavailable
+    redis.enableOfflineQueue = true;
+    const logger = new Logger('Utapi', { level: log.logLevel,
+        dump: log.dumpLevel });
+    const redisClient = new Redis(redis);
+    const datastore = new Datastore().setClient(redisClient);
+
+    redisClient.on('error', err => logger.trace('error with redis client', {
+        error: err,
+    }));
     const cluster = new Clustering(workers, logger);
-    cluster.start(current => {
-        const server = new UtapiServer(current);
+    cluster.start(worker => {
+        const server = new UtapiServer(worker, datastore, logger);
         server.startup();
     });
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "babel-plugin-transform-es2015-destructuring": "^6.1.18",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.2.0",
     "babel-plugin-transform-es2015-parameters": "^6.2.0",
-    "redis": "^2.6.2",
+    "ioredis": "^2.3.0",
     "werelogs": "scality/werelogs"
   },
   "devDependencies": {


### PR DESCRIPTION
- Datstore class wraps Redis client interface exposing the methods
  currently needed for accessing metrics.
  Use ioredis instead of redis npm module as its has more features
  and supports sentinel.
- By default, the server tries to connect to a standalone redis server
  at localhost:6379. If sentinel config is provided, redis client connects
  to the sentinel instead. This makes it easier for local development and
  production depoloyments.
