### PR TITLE
fix: use counters to update metrics

### DIFF
--- a/lib/Buckets.js
+++ b/lib/Buckets.js
@@ -45,12 +45,16 @@ export default class Buckets {
                     's3:UploadPart': 0,
                     's3:ListBucketMultipartUploads': 0,
                     's3:ListMultipartUploadParts': 0,
+                    's3:InitiateMultipartUpload': 0,
+                    's3:CompleteMultipartUpload': 0,
                     's3:AbortMultipartUpload': 0,
                     's3:DeleteObject': 0,
                     's3:GetObject': 0,
                     's3:GetObjectAcl': 0,
                     's3:PutObjectAcl': 0,
                     's3:ListAllMyBuckets': 0,
+                    's3:HeadBucket': 0,
+                    's3:HeadObject': 0,
                 },
             };
             /**
@@ -72,12 +76,13 @@ export default class Buckets {
                 } else if (item[1].length > 0) {
                     // convert strings to numbers and sort them
                     // TODO: find a efficient way to avoid sorting
-                    const values = item[1].map(v => {
-                        const tmp = parseInt(v, 10);
-                        return Number.isNaN(parseInt(v, 10)) ? 0 : tmp;
-                    });
                     const m = Buckets.getMetricFromKey(key, bucket);
                     if (m === 'storageUtilized' || m === 'numberOfObjects') {
+                        const values = item[1].map(v => {
+                            const tmp = parseInt(v, 10);
+                            return Number.isNaN(parseInt(v, 10)) ? 0 : tmp;
+                        });
+
                         values.sort((a, b) => a - b);
                         // pick min and max values
                         const min = values.shift();
@@ -86,6 +91,11 @@ export default class Buckets {
                         bucketRes[m][0] = min;
                         bucketRes[m][1] = max;
                     } else if (m === 'incomingBytes' || m === 'outgoingBytes') {
+                        const values = item[1].map(v => {
+                            const tmp = parseInt(v, 10);
+                            return Number.isNaN(parseInt(v, 10)) ? 0 : tmp;
+                        });
+
                         values.sort((a, b) => a - b);
                         // pick min and max values
                         const min = values.shift();
@@ -93,8 +103,9 @@ export default class Buckets {
                         const max = values.pop() || min;
                         bucketRes[m] = max;
                     } else {
-                        bucketRes.operations[`s3:${m}`] =
-                            values.reduce((prev, curr) => prev + curr, 0);
+                        // count is enough as it represents the delta of the
+                        // metric between the two timestamps
+                        bucketRes.operations[`s3:${m}`] = item[1].length || 0;
                     }
                 }
             });

--- a/lib/UtapiClient.js
+++ b/lib/UtapiClient.js
@@ -46,8 +46,18 @@ export default class UtapiClient {
             method: 'UtapiClient.pushMetricCreateBucket',
             bucket, timestamp,
         });
-        return this.ds.zadd(genBucketKey(bucket, 'createBucket'), timestamp,
-            1, callback);
+        return this.ds.incr(genBucketKey(bucket, 'createBucketCounter'),
+            (err, count) => {
+                if (err) {
+                    this.log.error('error incrementing counter', {
+                        method: 'Buckets.pushMetricCreateBucket',
+                        error: err,
+                    });
+                    return cb(err);
+                }
+                return this.ds.zadd(genBucketKey(bucket, 'createBucket'),
+                    timestamp, count, callback);
+            });
     }
 
     /**
@@ -73,8 +83,19 @@ export default class UtapiClient {
              ['set', genBucketKey(bucket, 'incomingBytesCounter'), 0],
              ['set', genBucketKey(bucket, 'outgoingBytesCounter'), 0],
              ['set', genBucketKey(bucket, 'numberOfObjectsCounter'), 0],
-             ['zadd', genBucketKey(bucket, 'deleteBucket'), timestamp, 1],
-        ], callback);
+             ['incr', genBucketKey(bucket, 'deleteBucketCounter')],
+        ], err => {
+            if (err) {
+                this.log.error('error incrementing counter', {
+                    method: 'Buckets.pushMetricDeleteBucket',
+                    error: err,
+                });
+                return callback(err);
+            }
+            // results format [[null, '1'], [null, '5'], [null, '9']...]
+            return this.ds.zadd(genBucketKey(bucket, 'deleteBucket'), timestamp,
+                1, callback);
+        });
     }
 
 
@@ -94,8 +115,18 @@ export default class UtapiClient {
             method: 'UtapiClient.pushMetricListBucket',
             bucket, timestamp,
         });
-        return this.ds.zadd(genBucketKey(bucket, 'listBucket'), timestamp, 1,
-            callback);
+        return this.ds.incr(genBucketKey(bucket, 'listBucketCounter'),
+            (err, count) => {
+                if (err) {
+                    this.log.error('error incrementing counter', {
+                        method: 'Buckets.pushMetricListBucket',
+                        error: err,
+                    });
+                    return callback(err);
+                }
+                return this.ds.zadd(genBucketKey(bucket, 'listBucket'),
+                    timestamp, count, callback);
+            });
     }
 
     /**
@@ -113,8 +144,18 @@ export default class UtapiClient {
         this.log.trace('pushing metric', { method: 'UtapiClient.pushMetricGet' +
             'BucketAcl',
             bucket, timestamp });
-        return this.ds.zadd(genBucketKey(bucket, 'getBucketAcl'), timestamp,
-            1, callback);
+        return this.ds.incr(genBucketKey(bucket, 'getBucketAclCounter'),
+            (err, count) => {
+                if (err) {
+                    this.log.error('error incrementing counter', {
+                        method: 'Buckets.pushMetricGetBucketAcl',
+                        error: err,
+                    });
+                    return callback(err);
+                }
+                return this.ds.zadd(genBucketKey(bucket, 'getBucketAcl'),
+                    timestamp, count, callback);
+            });
     }
 
     /**
@@ -131,8 +172,18 @@ export default class UtapiClient {
         }
         this.log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricPutBucketAcl', bucket, timestamp });
-        return this.ds.zadd(genBucketKey(bucket, 'putBucketAcl'), timestamp,
-            1, callback);
+        return this.ds.incr(genBucketKey(bucket, 'putBucketAclCounter'),
+            (err, count) => {
+                if (err) {
+                    this.log.error('error incrementing counter', {
+                        method: 'Buckets.pushMetricPutBucketAcl',
+                        error: err,
+                    });
+                    return callback(err);
+                }
+                return this.ds.zadd(genBucketKey(bucket, 'putBucketAcl'),
+                    timestamp, count, callback);
+            });
     }
 
     /**
@@ -156,6 +207,7 @@ export default class UtapiClient {
                 objectSize],
             ['incrby', genBucketKey(bucket, 'incomingBytesCounter'),
                 objectSize],
+            ['incr', genBucketKey(bucket, 'uploadPartCounter')],
         ], (err, results) => {
             if (err) {
                 this.log.error('error pushing metric', {
@@ -178,8 +230,8 @@ export default class UtapiClient {
                 });
             } else {
                 cmds.push(['zadd',
-                    genBucketKey(bucket, 'storageUtilized'),
-                    timestamp, actionCounter]);
+                    genBucketKey(bucket, 'storageUtilized'), timestamp,
+                        actionCounter]);
             }
 
             // incoming bytes counter
@@ -196,10 +248,19 @@ export default class UtapiClient {
                     genBucketKey(bucket, 'incomingBytes'),
                     timestamp, actionCounter]);
             }
-
-            // number of logUploadPart actions
-            cmds.push(['zadd', genBucketKey(bucket, 'uploadPart'), timestamp,
-                1]);
+            // uploadPart counter
+            actionErr = results[2][0];
+            actionCounter = results[2][1];
+            if (actionErr) {
+                this.log.error('error incrementing counter for push metric', {
+                    method: 'UtapiClient.pushMetricUploadPart',
+                    metric: 'uploadPart',
+                    error: actionErr,
+                });
+            } else {
+                cmds.push(['zadd', genBucketKey(bucket, 'uploadPart'),
+                    timestamp, actionCounter]);
+            }
             return this.ds.batch(cmds, callback);
         });
     }
@@ -220,8 +281,20 @@ export default class UtapiClient {
             method: 'UtapiClient.pushMetricInitiateMultipartUpload',
             bucket, timestamp,
         });
-        return this.ds.zadd(genBucketKey(bucket, 'initiateMultipartUpload'),
-            timestamp, 1, callback);
+        return this.ds.incr(
+            genBucketKey(bucket, 'initiateMultipartUploadCounter'),
+            (err, count) => {
+                if (err) {
+                    this.log('error incrementing counter', {
+                        method: 'UtapiClient.pushMetricInitiateMultipartUpload',
+                        error: err,
+                    });
+                    return callback(err);
+                }
+                return this.ds.zadd(
+                    genBucketKey(bucket, 'initiateMultipartUpload'),
+                    timestamp, count, callback);
+            });
     }
 
     /**
@@ -240,28 +313,53 @@ export default class UtapiClient {
             method: 'UtapiClient.pushMetricCompleteMultipartUpload',
             bucket, timestamp,
         });
-        return this.ds.incr(
-            genBucketKey(bucket, 'numberOfObjectsCounter'),
-            (err, objCount) => {
-                // number of objects counter
-                if (err) {
-                    this.log.error('error incrementing counter for push metric',
-                        {
-                            method: 'UtapiClient.pushMetricPutObject',
-                            metric: 'number of objects',
-                            error: err,
-                        });
-                    return callback(err);
-                }
-                const cmds = [];
+        return this.ds.batch([
+            ['incr', genBucketKey(bucket, 'numberOfObjectsCounter')],
+            ['incr', genBucketKey(bucket, 'completeMultipartUploadCounter')],
+        ], (err, results) => {
+            // number of objects counter
+            if (err) {
+                this.log.error('error incrementing counter for push metric',
+                    {
+                        method: 'UtapiClient.pushMetricPutObject',
+                        metric: 'number of objects',
+                        error: err,
+                    });
+                return callback(err);
+            }
+            const cmds = [];
+            let actionErr;
+            let actionCounter;
+            // storage utilized counter
+            actionErr = results[0][0];
+            actionCounter = results[0][1];
+            if (actionErr) {
+                this.log.error('error incrementing counter for push metric', {
+                    method: 'UtapiClient.pushMetricCompleteMultipartUpload',
+                    metric: 'number of objects',
+                    error: actionErr,
+                });
+            } else {
                 cmds.push(['zadd', genBucketKey(bucket, 'numberOfObjects'),
-                    timestamp, objCount]);
-                // number of PutObject actions
+                    timestamp, actionCounter]);
+            }
+
+            // completeMultipartUpload counter
+            actionErr = results[1][0];
+            actionCounter = results[1][1];
+            if (actionErr) {
+                this.log.error('error incrementing counter for push metric', {
+                    method: 'UtapiClient.pushMetricCompleteMultipartUpload',
+                    metric: 'number of objects',
+                    error: actionErr,
+                });
+            } else {
                 cmds.push(['zadd',
                     genBucketKey(bucket, 'completeMultipartUpload'),
-                    timestamp, 1]);
-                return this.ds.batch(cmds, callback);
-            });
+                    timestamp, actionCounter]);
+            }
+            return this.ds.batch(cmds, callback);
+        });
     }
 
     /**
@@ -280,9 +378,21 @@ export default class UtapiClient {
             method: 'UtapiClient.pushMetricListBucketMultipartUploads',
             bucket, timestamp,
         });
-        return this.ds.zadd(
-            genBucketKey(bucket, 'listBucketMultipartUploads'),
-            timestamp, 1, callback);
+        return this.ds.incr(
+            genBucketKey(bucket, 'listBucketMultipartUploadsCounter'),
+            (err, count) => {
+                if (err) {
+                    this.log('error incrementing counter', {
+                        method: 'UtapiClient.pushMetricListBucketMultipart' +
+                            'Uploads',
+                        error: err,
+                    });
+                    return callback(err);
+                }
+                return this.ds.zadd(
+                    genBucketKey(bucket, 'listBucketMultipartUploads'),
+                    timestamp, count, callback);
+            });
     }
 
     /**
@@ -301,8 +411,21 @@ export default class UtapiClient {
             method: 'UtapiClient.pushMetricListMultipartUploadParts',
             bucket, timestamp,
         });
-        return this.ds.zadd(genBucketKey(bucket, 'listMultipartUploadParts'),
-            timestamp, 1, callback);
+        return this.ds.incr(
+            genBucketKey(bucket, 'listMultipartUploadPartsCounter'),
+            (err, count) => {
+                if (err) {
+                    this.log('error incrementing counter', {
+                        method: 'UtapiClient.pushMetricListMultipartUpload' +
+                            'Parts',
+                        error: err,
+                    });
+                    return callback(err);
+                }
+                return this.ds.zadd(
+                    genBucketKey(bucket, 'listMultipartUploadParts'),
+                    timestamp, count, callback);
+            });
     }
 
     /**
@@ -321,8 +444,20 @@ export default class UtapiClient {
             method: 'UtapiClient.pushMetricAbortMultipartUpload',
             bucket, timestamp,
         });
-        return this.ds.zadd(genBucketKey(bucket, 'abortMultipartUpload'),
-            timestamp, 1, callback);
+        return this.ds.incr(
+            genBucketKey(bucket, 'abortMultipartUploadCounter'),
+            (err, count) => {
+                if (err) {
+                    this.log('error incrementing counter', {
+                        method: 'UtapiClient.pushMetricAbortMultipartUpload',
+                        error: err,
+                    });
+                    return callback(err);
+                }
+                return this.ds.zadd(
+                    genBucketKey(bucket, 'abortMultipartUpload'),
+                    timestamp, count, callback);
+            });
     }
 
     /**
@@ -341,8 +476,18 @@ export default class UtapiClient {
             method: 'UtapiClient.pushMetricDeleteObject',
             bucket, timestamp,
         });
-        return this.ds.zadd(genBucketKey(bucket, 'deleteObject'), timestamp,
-            1, callback);
+        return this.ds.incr(genBucketKey(bucket, 'deleteObjectCounter'),
+            (err, count) => {
+                if (err) {
+                    this.log('error incrementing counter', {
+                        method: 'UtapiClient.pushMetricDeleteObject',
+                        error: err,
+                    });
+                    return callback(err);
+                }
+                return this.ds.zadd(genBucketKey(bucket, 'deleteObject'),
+                    timestamp, count, callback);
+            });
     }
 
     /**
@@ -364,6 +509,7 @@ export default class UtapiClient {
         return this.ds.batch([
             ['incrby', genBucketKey(bucket, 'outgoingBytesCounter'),
             objectSize],
+            ['incr', genBucketKey(bucket, 'outgoingBytesCounter')],
         ], (err, results) => {
             if (err) {
                 this.log.error('error pushing metric', {
@@ -374,8 +520,8 @@ export default class UtapiClient {
             }
             const cmds = [];
             // storage utilized counter
-            const actionErr = results[0][0];
-            const actionCounter = results[0][1];
+            let actionErr = results[0][0];
+            let actionCounter = results[0][1];
             if (actionErr) {
                 this.log.error('error incrementing counter for push metric', {
                     method: 'UtapiClient.pushMetricGetObject',
@@ -388,9 +534,19 @@ export default class UtapiClient {
                     timestamp, actionCounter]);
             }
 
-            // number of GetObject actions
-            cmds.push(['zadd', genBucketKey(bucket, 'getObject'), timestamp,
-                1]);
+            // get object counter
+            actionErr = results[1][0];
+            actionCounter = results[1][1];
+            if (actionErr) {
+                this.log.error('error incrementing counter for push metric', {
+                    method: 'UtapiClient.pushMetricGetObject',
+                    metric: 'outgoing bytes',
+                    error: actionErr,
+                });
+            } else {
+                cmds.push(['zadd', genBucketKey(bucket, 'getObject'), timestamp,
+                    actionCounter]);
+            }
             return this.ds.batch(cmds, callback);
         });
     }
@@ -411,8 +567,18 @@ export default class UtapiClient {
             method: 'UtapiClient.pushMetricGetObjectAcl',
             bucket, timestamp,
         });
-        return this.ds.zadd(genBucketKey(bucket, 'getObjectAcl'), timestamp,
-            1, callback);
+        return this.ds.incr(genBucketKey(bucket, 'getObjectAclCounter'),
+            (err, count) => {
+                if (err) {
+                    this.log('error incrementing counter', {
+                        method: 'UtapiClient.pushMetricGetObjectAcl',
+                        error: err,
+                    });
+                    return callback(err);
+                }
+                return this.ds.zadd(genBucketKey(bucket, 'getObjectAcl'),
+                    timestamp, count, callback);
+            });
     }
 
 
@@ -438,6 +604,7 @@ export default class UtapiClient {
             ['incrby', genBucketKey(bucket, 'incomingBytesCounter'),
                 objectSize],
             ['incr', genBucketKey(bucket, 'numberOfObjectsCounter')],
+            ['incr', genBucketKey(bucket, 'putObjectCounter')],
         ], (err, results) => {
             if (err) {
                 this.log.error('error pushing metric', {
@@ -493,9 +660,20 @@ export default class UtapiClient {
                     genBucketKey(bucket, 'numberOfObjects'), timestamp,
                     actionCounter]);
             }
-            // number of PutObject actions
-            cmds.push(['zadd', genBucketKey(bucket, 'putObject'), timestamp,
-                1]);
+
+            // putObject counter
+            actionErr = results[3][0];
+            actionCounter = results[3][1];
+            if (actionErr) {
+                this.log.error('error incrementing counter for push metric', {
+                    method: 'UtapiClient.pushMetricPutObject',
+                    metric: 'put object',
+                    error: actionErr,
+                });
+            } else {
+                cmds.push(['zadd', genBucketKey(bucket, 'putObject'), timestamp,
+                    actionCounter]);
+            }
             return this.ds.batch(cmds, callback);
         });
     }
@@ -516,8 +694,18 @@ export default class UtapiClient {
             method: 'UtapiClient.pushMetricPutObjectAcl',
             bucket, timestamp,
         });
-        return this.ds.zadd(genBucketKey(bucket, 'putObjectAcl'), timestamp,
-            1, callback);
+        return this.ds.incr(genBucketKey(bucket, 'putObjectAclCounter'),
+            (err, count) => {
+                if (err) {
+                    this.log('error incrementing counter', {
+                        method: 'UtapiClient.pushMetricPutObjectAcl',
+                        error: err,
+                    });
+                    return callback(err);
+                }
+                return this.ds.zadd(genBucketKey(bucket, 'putObjectAcl'),
+                    timestamp, count, callback);
+            });
     }
 
     /**
@@ -536,8 +724,18 @@ export default class UtapiClient {
             method: 'UtapiClient.pushMetricHeadBucket',
             bucket, timestamp,
         });
-        return this.ds.zadd(genBucketKey(bucket, 'headBucket'), timestamp, 1,
-            callback);
+        return this.ds.incr(genBucketKey(bucket, 'headBucketCounter'),
+            (err, count) => {
+                if (err) {
+                    this.log('error incrementing counter', {
+                        method: 'UtapiClient.pushMetricHeadBucket',
+                        error: err,
+                    });
+                    return callback(err);
+                }
+                return this.ds.zadd(genBucketKey(bucket, 'headBucket'),
+                    timestamp, count, callback);
+            });
     }
 
     /**
@@ -556,7 +754,17 @@ export default class UtapiClient {
             method: 'UtapiClient.pushMetricHeadObject',
             bucket, timestamp,
         });
-        return this.ds.zadd(genBucketKey(bucket, 'headObject'), timestamp, 1,
-            callback);
+        return this.ds.incr(genBucketKey(bucket, 'headObjectCounter'),
+            (err, count) => {
+                if (err) {
+                    this.log('error incrementing counter', {
+                        method: 'UtapiClient.pushMetricHeadObject',
+                        error: err,
+                    });
+                    return callback(err);
+                }
+                return this.ds.zadd(genBucketKey(bucket, 'headObject'),
+                    timestamp, count, callback);
+            });
     }
 }

--- a/lib/UtapiClient.js
+++ b/lib/UtapiClient.js
@@ -69,10 +69,10 @@ export default class UtapiClient {
         });
         // clear global counters and log the action
         return this.ds.batch([
-             ['set', genBucketKey(bucket, 'bucketStorageUtilizedCounter'), 0],
-             ['set', genBucketKey(bucket, 'bucketIncomingBytesCounter'), 0],
-             ['set', genBucketKey(bucket, 'bucketOutgoingBytesCounter'), 0],
-             ['set', genBucketKey(bucket, 'bucketNumberOfObjectsCounter'), 0],
+             ['set', genBucketKey(bucket, 'storageUtilizedCounter'), 0],
+             ['set', genBucketKey(bucket, 'incomingBytesCounter'), 0],
+             ['set', genBucketKey(bucket, 'outgoingBytesCounter'), 0],
+             ['set', genBucketKey(bucket, 'numberOfObjectsCounter'), 0],
              ['zadd', genBucketKey(bucket, 'deleteBucket'), timestamp, 1],
         ], callback);
     }
@@ -152,9 +152,9 @@ export default class UtapiClient {
             method: 'UtapiClient.pushMetricUploadPart', bucket, timestamp });
         // update counters
         return this.ds.batch([
-            ['incrby', genBucketKey(bucket, 'bucketStorageUtilizedCounter'),
+            ['incrby', genBucketKey(bucket, 'storageUtilizedCounter'),
                 objectSize],
-            ['incrby', genBucketKey(bucket, 'bucketIncomingBytesCounter'),
+            ['incrby', genBucketKey(bucket, 'incomingBytesCounter'),
                 objectSize],
         ], (err, results) => {
             if (err) {
@@ -241,7 +241,7 @@ export default class UtapiClient {
             bucket, timestamp,
         });
         return this.ds.incr(
-            genBucketKey(bucket, 'bucketNumberOfObjectsCounter'),
+            genBucketKey(bucket, 'numberOfObjectsCounter'),
             (err, objCount) => {
                 // number of objects counter
                 if (err) {
@@ -362,7 +362,7 @@ export default class UtapiClient {
             method: 'UtapiClient.pushMetricGetObject', bucket, timestamp });
         // update counters
         return this.ds.batch([
-            ['incrby', genBucketKey(bucket, 'bucketOutgoingBytesCounter'),
+            ['incrby', genBucketKey(bucket, 'outgoingBytesCounter'),
             objectSize],
         ], (err, results) => {
             if (err) {
@@ -433,11 +433,11 @@ export default class UtapiClient {
             { method: 'UtapiClient.pushMetricPutObject', bucket, timestamp });
         // update counters
         return this.ds.batch([
-            ['incrby', genBucketKey(bucket, 'bucketStorageUtilizedCounter'),
+            ['incrby', genBucketKey(bucket, 'storageUtilizedCounter'),
                 objectSize],
-            ['incrby', genBucketKey(bucket, 'bucketIncomingBytesCounter'),
+            ['incrby', genBucketKey(bucket, 'incomingBytesCounter'),
                 objectSize],
-            ['incr', genBucketKey(bucket, 'bucketNumberOfObjectsCounter')],
+            ['incr', genBucketKey(bucket, 'numberOfObjectsCounter')],
         ], (err, results) => {
             if (err) {
                 this.log.error('error pushing metric', {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -28,14 +28,39 @@ const bucketKeys = {
     headBucket: bucket => `s3:buckets:${bucket}:HeadBucket`,
     headObject: bucket => `s3:buckets:${bucket}:HeadObject`,
     listAllMyBuckets: bucket => `s3:buckets:${bucket}:ListAllMyBuckets`,
-    bucketStorageUtilizedCounter: bucket =>
+    storageUtilizedCounter: bucket =>
         `s3:buckets:${bucket}:storageUtilized:counter`,
-    bucketIncomingBytesCounter: bucket =>
+    incomingBytesCounter: bucket =>
         `s3:buckets:${bucket}:incomingBytes:counter`,
-    bucketOutgoingBytesCounter: bucket =>
+    outgoingBytesCounter: bucket =>
         `s3:buckets:${bucket}:outgoingBytes:counter`,
-    bucketNumberOfObjectsCounter: bucket =>
+    numberOfObjectsCounter: bucket =>
         `s3:buckets:${bucket}:numberOfObjects:counter`,
+    createBucketCounter: bucket => `s3:buckets:${bucket}:CreateBucket:counter`,
+    deleteBucketCounter: bucket => `s3:buckets:${bucket}:DeleteBucket:counter`,
+    listBucketCounter: bucket => `s3:buckets:${bucket}:ListBucket:counter`,
+    getBucketAclCounter: bucket => `s3:buckets:${bucket}:GetBucketAcl:counter`,
+    putBucketAclCounter: bucket => `s3:buckets:${bucket}:PutBucketAcl:counter`,
+    listBucketMultipartUploadsCounter: bucket =>
+        `s3:buckets:${bucket}:ListBucketMultipartUploads:counter`,
+    listMultipartUploadPartsCounter: bucket =>
+        `s3:buckets:${bucket}:ListMultipartUploadParts:counter`,
+    initiateMultipartUploadCounter: bucket =>
+        `s3:buckets:${bucket}:InitiateMultipartUpload:counter`,
+    completeMultipartUploadCounter: bucket =>
+        `s3:buckets:${bucket}:CompleteMultipartUpload:counter`,
+    abortMultipartUploadCounter: bucket =>
+        `s3:buckets:${bucket}:AbortMultipartUpload:counter`,
+    deleteObjectCounter: bucket => `s3:buckets:${bucket}:DeleteObject:counter`,
+    uploadPartCounter: bucket => `s3:buckets:${bucket}:UploadPart:counter`,
+    getObjectCounter: bucket => `s3:buckets:${bucket}:GetObject:counter`,
+    getObjectAclCounter: bucket => `s3:buckets:${bucket}:GetObjectAcl:counter`,
+    putObjectCounter: bucket => `s3:buckets:${bucket}:PutObject:counter`,
+    putObjectAclCounter: bucket => `s3:buckets:${bucket}:PutObjectAcl:counter`,
+    headBucketCounter: bucket => `s3:buckets:${bucket}:HeadBucket:counter`,
+    headObjectCounter: bucket => `s3:buckets:${bucket}:HeadObject:counter`,
+    listAllMyBucketsCounter: bucket =>
+        `s3:buckets:${bucket}:ListAllMyBuckets:counter`,
 };
 
 /**


### PR DESCRIPTION
Sorted sets require unique count to store time series style
keys and values
