### PR TITLE
BF: Set counters to 0 on bucket creation

### DIFF
--- a/lib/UtapiClient.js
+++ b/lib/UtapiClient.js
@@ -1,6 +1,6 @@
 import { Logger } from 'werelogs';
 import Datastore from './Datastore';
-import { genBucketKey } from './schema';
+import { genBucketKey, getBucketGlobalCounters } from './schema';
 import redisClient from '../utils/redisClient';
 
 export default class UtapiClient {
@@ -46,23 +46,34 @@ export default class UtapiClient {
             method: 'UtapiClient.pushMetricCreateBucket',
             bucket, timestamp,
         });
-        return this.ds.incr(genBucketKey(bucket, 'createBucketCounter'),
-            (err, count) => {
-                if (err) {
-                    this.log.error('error incrementing counter', {
-                        method: 'Buckets.pushMetricCreateBucket',
-                        error: err,
-                    });
-                    return callback(err);
-                }
-                return this.ds.zadd(genBucketKey(bucket, 'createBucket'),
-                    timestamp, count, callback);
-            });
+        const cmds = [];
+        // set global counters to 0 except for create bucket counter (set to 1)
+        // indicating start of bucket timeline
+        getBucketGlobalCounters(bucket).forEach(item => {
+            if (item.indexOf('createBucketCounter') !== -1) {
+                cmds.push(['set', item, 1]);
+            } else {
+                cmds.push(['set', item, 0]);
+            }
+        });
+        return this.ds.batch(cmds, err => {
+            if (err) {
+                this.log.error('error incrementing counter', {
+                    method: 'Buckets.pushMetricCreateBucket',
+                    error: err,
+                });
+                return callback(err);
+            }
+            return this.ds.batch([
+                ['zadd', genBucketKey(bucket, 'createBucket'), timestamp, 1],
+                ['zadd', genBucketKey(bucket, 'storageUtilized'), timestamp, 0],
+                ['zadd', genBucketKey(bucket, 'numberOfObjects'), timestamp, 0],
+            ], callback);
+        });
     }
 
     /**
-    * Updates counter for DeleteBucket action on a Bucket resource. Since delete
-    * bucket occcurs only once in a bucket's lifetime, counter is  always 1
+    * Updates counter for DeleteBucket action on a Bucket resource
     * @param {string} bucket - bucket name
     * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
@@ -77,14 +88,8 @@ export default class UtapiClient {
             method: 'UtapiClient.pushMetricDeleteBucket',
             bucket, timestamp,
         });
-        // clear global counters and log the action
-        return this.ds.batch([
-             ['set', genBucketKey(bucket, 'storageUtilizedCounter'), 0],
-             ['set', genBucketKey(bucket, 'incomingBytesCounter'), 0],
-             ['set', genBucketKey(bucket, 'outgoingBytesCounter'), 0],
-             ['set', genBucketKey(bucket, 'numberOfObjectsCounter'), 0],
-             ['incr', genBucketKey(bucket, 'deleteBucketCounter')],
-        ], err => {
+        const key = genBucketKey(bucket, 'deleteBucketCounter');
+        return this.ds.set(key, 1, err => {
             if (err) {
                 this.log.error('error incrementing counter', {
                     method: 'Buckets.pushMetricDeleteBucket',
@@ -92,7 +97,6 @@ export default class UtapiClient {
                 });
                 return callback(err);
             }
-            // results format [[null, '1'], [null, '5'], [null, '9']...]
             return this.ds.zadd(genBucketKey(bucket, 'deleteBucket'), timestamp,
                 1, callback);
         });

--- a/lib/backend/memory.js
+++ b/lib/backend/memory.js
@@ -1,0 +1,93 @@
+import map from 'async/map';
+
+export default class Memory {
+    constructor() {
+        this.data = {};
+    }
+
+    set(key, value, cb) {
+        process.nextTick(() => {
+            this.data[key] = value;
+            return cb(null, value);
+        });
+    }
+
+    get(key, cb) {
+        process.nextTick(() => cb(null, this.data[key]));
+    }
+
+    incr(key, cb) {
+        process.nextTick(() => {
+            if (this.data[key] === undefined) {
+                this.data[key] = 0;
+            }
+            return cb(null, this.data[key]++);
+        });
+    }
+
+    zadd(key, score, value, cb) {
+        process.nextTick(() => {
+            if (this.data[key] === undefined) {
+                this.data[key] = [];
+            }
+            const found = this.data[key].some(item =>
+                JSON.stringify(item) === JSON.stringify([score, value]));
+            if (!found) {
+                this.data[key].push([score, value]);
+                this.data[key].sort((a, b) => a[0] - b[0]);
+            }
+            return cb(null, value);
+        });
+    }
+
+    zrangebyscore(key, min, max, cb) {
+        process.nextTick(() => {
+            let minKey;
+            let maxKey;
+            const result = [];
+            this.data[key].some(item => {
+                if (minKey !== undefined && maxKey !== undefined) {
+                    return true;
+                }
+                if (minKey !== undefined && minKey <= item[0]) {
+                    minKey = key;
+                    return false;
+                }
+                if (maxKey !== undefined && maxKey >= item[0]) {
+                    maxKey = key;
+                    return false;
+                }
+                return false;
+            });
+            if (minKey !== undefined) {
+                this.data[key].forEach(item => {
+                    if (item[0] === minKey) {
+                        result.push([null, item[1]]);
+                    }
+                });
+            }
+            if (maxKey !== undefined) {
+                this.data[key].forEach(item => {
+                    if (item[0] === maxKey) {
+                        result.push([null, item[1]]);
+                    }
+                });
+            }
+            return cb(null, result);
+        });
+    }
+
+    zrevragebyscore(key, min, max, cb) {
+        return this.zrangebyscore(key, max, min, cb);
+    }
+
+    pipeline(cmds) {
+        this.cmds = cmds;
+        this.exec = cb => {
+            process.nextTick(() => {
+                map(this.cmds,
+                    (item, next) => this[item.shift()](...item, next), cb);
+            });
+        };
+    }
+}


### PR DESCRIPTION
On bucket creation, the global counters need to be set/reset to 0 indicating
the start of the bucket timeline.

Fix #22