### PR TITLE
BF: Reset counters

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,3 +10,4 @@ test:
     override:
         - npm run --silent lint_md
         - npm run --silent lint
+        - npm run ft_test

--- a/lib/UtapiClient.js
+++ b/lib/UtapiClient.js
@@ -1,6 +1,6 @@
 import { Logger } from 'werelogs';
 import Datastore from './Datastore';
-import { genBucketKey } from './schema';
+import { genBucketKey, getBucketGlobalCounters } from './schema';
 import redisClient from '../utils/redisClient';
 
 export default class UtapiClient {
@@ -22,6 +22,17 @@ export default class UtapiClient {
                 .setClient(redisClient(config.redis, this.log));
             this.disableClient = false;
         }
+    }
+
+    /**
+    * set datastore
+    * @param {DataStore} ds - Datastore instance
+    * @return {object} current instance
+    */
+    setDataStore(ds) {
+        this.ds = ds;
+        this.disableClient = false;
+        return this;
     }
 
     /*
@@ -46,23 +57,34 @@ export default class UtapiClient {
             method: 'UtapiClient.pushMetricCreateBucket',
             bucket, timestamp,
         });
-        return this.ds.incr(genBucketKey(bucket, 'createBucketCounter'),
-            (err, count) => {
-                if (err) {
-                    this.log.error('error incrementing counter', {
-                        method: 'Buckets.pushMetricCreateBucket',
-                        error: err,
-                    });
-                    return callback(err);
-                }
-                return this.ds.zadd(genBucketKey(bucket, 'createBucket'),
-                    timestamp, count, callback);
-            });
+        const cmds = [];
+        // set global counters to 0 except for create bucket counter (set to 1)
+        // indicating start of bucket timeline
+        getBucketGlobalCounters(bucket).forEach(item => {
+            if (item.indexOf('CreateBucket:counter') !== -1) {
+                cmds.push(['set', item, 1]);
+            } else {
+                cmds.push(['set', item, 0]);
+            }
+        });
+        return this.ds.batch(cmds, err => {
+            if (err) {
+                this.log.error('error incrementing counter', {
+                    method: 'Buckets.pushMetricCreateBucket',
+                    error: err,
+                });
+                return callback(err);
+            }
+            return this.ds.batch([
+                ['zadd', genBucketKey(bucket, 'createBucket'), timestamp, 1],
+                ['zadd', genBucketKey(bucket, 'storageUtilized'), timestamp, 0],
+                ['zadd', genBucketKey(bucket, 'numberOfObjects'), timestamp, 0],
+            ], callback);
+        });
     }
 
     /**
-    * Updates counter for DeleteBucket action on a Bucket resource. Since delete
-    * bucket occcurs only once in a bucket's lifetime, counter is  always 1
+    * Updates counter for DeleteBucket action on a Bucket resource
     * @param {string} bucket - bucket name
     * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
@@ -77,14 +99,8 @@ export default class UtapiClient {
             method: 'UtapiClient.pushMetricDeleteBucket',
             bucket, timestamp,
         });
-        // clear global counters and log the action
-        return this.ds.batch([
-             ['set', genBucketKey(bucket, 'storageUtilizedCounter'), 0],
-             ['set', genBucketKey(bucket, 'incomingBytesCounter'), 0],
-             ['set', genBucketKey(bucket, 'outgoingBytesCounter'), 0],
-             ['set', genBucketKey(bucket, 'numberOfObjectsCounter'), 0],
-             ['incr', genBucketKey(bucket, 'deleteBucketCounter')],
-        ], err => {
+        const key = genBucketKey(bucket, 'deleteBucketCounter');
+        return this.ds.set(key, 1, err => {
             if (err) {
                 this.log.error('error incrementing counter', {
                     method: 'Buckets.pushMetricDeleteBucket',
@@ -92,7 +108,6 @@ export default class UtapiClient {
                 });
                 return callback(err);
             }
-            // results format [[null, '1'], [null, '5'], [null, '9']...]
             return this.ds.zadd(genBucketKey(bucket, 'deleteBucket'), timestamp,
                 1, callback);
         });

--- a/lib/backend/Memory.js
+++ b/lib/backend/Memory.js
@@ -1,0 +1,241 @@
+import map from 'async/map';
+
+/**
+* Pipeline - executes multiple commands sent as a batch
+*/
+class Pipeline {
+    /**
+    * @constructor
+    * @param {array[]} cmds - array of commands
+    * typical usage looks like [['set', 'foo', 'bar'], ['get', 'foo']]
+    * @param {Memory} db - Memory instance
+    */
+    constructor(cmds, db) {
+        this.cmds = cmds;
+        this.db = db;
+    }
+
+    /**
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    exec(cb) {
+        process.nextTick(() => {
+            // e.g. [['set', 'foo', 'bar'], ['get', 'foo']]
+            map(this.cmds, (item, next) => {
+                // ['set', 'foo', 'bar']
+                const fnName = item.shift();
+                // arg1 = 'foo', arg2 = 'bar', arg2 = undefined
+                const [arg1, arg2, arg3] = item;
+                if (arg1 !== undefined && arg2 !== undefined
+                    && arg3 !== undefined) {
+                    return this.db[fnName](arg1, arg2, arg3,
+                        (err, res) => next(null, [err, res]));
+                }
+                if (arg1 !== undefined && arg2 !== undefined) {
+                    return this.db[fnName](arg1, arg2,
+                        (err, res) => next(null, [err, res]));
+                }
+                return this.db[fnName](arg1,
+                    (err, res) => next(null, [err, res]));
+            }, cb);
+        });
+    }
+}
+
+/**
+* Memory backend which emulates IoRedis client methods
+*/
+export default class Memory {
+    constructor() {
+        this.data = {};
+    }
+
+    /**
+    * Set key to hold a value
+    * @param {string} key - data key
+    * @param {string} value - data value
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    set(key, value, cb) {
+        process.nextTick(() => {
+            this.data[key] = value;
+            return cb(null, value);
+        });
+    }
+
+    /**
+    * Get value from a key
+    * @param {string} key - data key
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    get(key, cb) {
+        process.nextTick(() => cb(null, this.data[key] === undefined ?
+            null : this.data[key]));
+    }
+
+    /**
+    * Increment value held by the key by 1
+    * @param {string} key - data key
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    incr(key, cb) {
+        process.nextTick(() => {
+            if (this.data[key] === undefined) {
+                this.data[key] = 0;
+            }
+            return cb(null, this.data[key]++);
+        });
+    }
+
+    /**
+    * Increment value held by the key by the given number
+    * @param {string} key - data key
+    * @param {number} num - number to increment by
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    incrby(key, num, cb) {
+        process.nextTick(() => {
+            if (this.data[key] === undefined) {
+                this.data[key] = 0;
+            }
+            this.data[key] += num;
+            return cb(null, this.data[key]);
+        });
+    }
+
+    /**
+    * Decrement value held by the key by 1
+    * @param {string} key - data key
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    decr(key, cb) {
+        process.nextTick(() => {
+            if (this.data[key] === undefined) {
+                this.data[key] = 0;
+            }
+            return cb(null, this.data[key]--);
+        });
+    }
+
+    /**
+    * Decrement value held by the key by the given number
+    * @param {string} key - data key
+    * @param {number} num - number to increment by
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    decrby(key, num, cb) {
+        process.nextTick(() => {
+            if (this.data[key] === undefined) {
+                this.data[key] = 0;
+            }
+            this.data[key] -= num;
+            return cb(null, this.data[key]);
+        });
+    }
+
+    /**
+    * Store value by score in a sorted set
+    * @param {string} key - data key
+    * @param {number} score - data score
+    * @param {number} value - data value
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    zadd(key, score, value, cb) {
+        process.nextTick(() => {
+            if (this.data[key] === undefined) {
+                this.data[key] = [];
+            }
+            // compares both arrays of data
+            const found = this.data[key].some(item =>
+                JSON.stringify(item) === JSON.stringify([score, value]));
+            if (!found) {
+                // as this is a sorted set emulation, it sorts the data by score
+                // after each insertion
+                this.data[key].push([score, value]);
+                this.data[key].sort((a, b) => a[0] - b[0]);
+            }
+            return cb(null, value);
+        });
+    }
+
+    /**
+    * Returns range result from sorted set at key with scores between min and
+    * max (all inclusive). Ordering is from low to high scores
+    * @param {string} key - data key
+    * @param {string|number} min - min score (number or -inf)
+    * @param {string|number} max - max score (number or +inf)
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    zrangebyscore(key, min, max, cb) {
+        process.nextTick(() => {
+            if (!this.data[key]) {
+                // emulating redis-client which returns nulls
+                return cb(null, null);
+            }
+            const minScore = (min === '-inf') ? this.data[key][0][0] : min;
+            const maxScore = (min === '+inf') ?
+                this.data[key][this.data[key].length - 1][0] : max;
+            return cb(null, this.data[key].filter(item => item[0] >= minScore
+                && item[0] <= maxScore).map(item => item[1]));
+        });
+    }
+
+    /**
+    * Returns range result from sorted set at key with scores between min and
+    * max (all inclusive). Ordering is from high to low scores
+    * @param {string} key - data key
+    * @param {string|number} max - max score (number or +inf)
+    * @param {string|number} min - min score (number or -inf)
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    zrevrangebyscore(key, max, min, cb) {
+        process.nextTick(() => {
+            if (!this.data[key]) {
+                // emulating redis-client which returns nulls
+                return cb(null, null);
+            }
+            const minScore = (min === '-inf') ? this.data[key][0][0] : min;
+            const maxScore = (min === '+inf') ?
+                this.data[key][this.data[key].length][0] : max;
+            const cloneKeyData = Object.assign(this.data[key]);
+            // Sort keys by scores in the decreasing order, if scores are equal
+            // sort by their value in the decreasing order
+            cloneKeyData.sort((a, b) => {
+                if (a[0] === b[0]) {
+                    return b[1] - a[1];
+                }
+                return b[0] - a[0];
+            });
+            return cb(null, cloneKeyData.filter(item => item[0] >= minScore
+                && item[0] <= maxScore).map(item => item[1]));
+        });
+    }
+
+    /**
+    * Returns a pipeline instance that can execute commmands as a batch
+    * @param {array} cmds - list of commands
+    * @return {Pipeline} - Pipeline instance
+    */
+    pipeline(cmds) {
+        return new Pipeline(cmds, this);
+    }
+
+    /**
+    * Flushes(clears) the data out from db
+    * @return {object} - current instance
+    */
+    flushDb() {
+        this.data = {};
+        return this;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "mocha": "^3.0.2"
   },
   "scripts": {
+    "ft_test": "mocha --compilers js:babel-core/register --recursive tests/functional",
     "lint": "eslint $(git ls-files '*.js')",
     "lint_md": "mdlint $(git ls-files '*.md')",
     "start": "node index.js"

--- a/tests/functional/testUtapiClient.js
+++ b/tests/functional/testUtapiClient.js
@@ -1,0 +1,60 @@
+import assert from 'assert';
+import { mapSeries, series } from 'async';
+import UtapiClient from '../../lib/UtapiClient';
+import MemoryBackend from '../../lib/backend/Memory';
+import Datastore from '../../lib/Datastore';
+import { getBucketGlobalCounters, getMetricFromKey } from '../../lib/schema';
+const testBucket = 'foo';
+const memBackend = new MemoryBackend();
+const datastore = new Datastore();
+const utapiClient = new UtapiClient();
+datastore.setClient(memBackend);
+utapiClient.setDataStore(datastore);
+
+function _assertCounters(bucket, cb) {
+    const gCounters = getBucketGlobalCounters(testBucket);
+    return mapSeries(gCounters, (item, next) =>
+        memBackend.get(item, (err, res) => {
+            if (err) {
+                return next(err);
+            }
+            const metric = getMetricFromKey(item, bucket)
+                .replace(':counter', '');
+            if (item.indexOf('CreateBucket') !== -1) {
+                assert.equal(res, 1, `${metric} must be 1`);
+            } else {
+                assert.equal(res, 0, `${metric} must be 0`);
+            }
+            return next();
+        }), cb);
+}
+
+describe('Counters', () => {
+    afterEach(() => memBackend.flushDb());
+
+    it('should set global counters (other than create bucket counter) to 0 on' +
+        ' bucket creation', done => {
+        const now = Date.now();
+        utapiClient.pushMetricCreateBucket(testBucket, now,
+            () => _assertCounters(testBucket, done));
+    });
+
+    it('should reset global counters on bucket re-creation', done => {
+        series([
+            next => utapiClient.pushMetricCreateBucket(testBucket, Date.now(),
+                next),
+            next => utapiClient.pushMetricListBucket(testBucket, Date.now(),
+                next),
+            next => utapiClient.pushMetricPutObject(testBucket, Date.now(), 8,
+                next),
+            next => utapiClient.pushMetricGetObject(testBucket, Date.now(), 8,
+                next),
+            next => utapiClient.pushMetricDeleteObject(testBucket, Date.now(),
+                8, next),
+            next => utapiClient.pushMetricDeleteBucket(testBucket, Date.now(),
+                next),
+            next => utapiClient.pushMetricCreateBucket(testBucket, Date.now(),
+                next),
+        ], () => _assertCounters(testBucket, done));
+    });
+});


### PR DESCRIPTION
- On bucket creation, the global counters need to be set/reset to 0 indicating
the start of the bucket timeline. Create bucket global counter is set to 1
since the action just occured.

Fix #22

- Implement in-memory backend to aid testing