### PR TITLE
fix: update storage utilized for object overwrites

### DIFF
--- a/lib/UtapiClient.js
+++ b/lib/UtapiClient.js
@@ -652,23 +652,40 @@ export default class UtapiClient {
     * @param {string} bucket - bucket name
     * @param {number} timestamp - unix epoch timestamp
     * @param {number} objectSize - size of object in bytes
+    * @param {number} prevObjectSize - previous size of object in bytes if this
+    * action overwrote an existing object
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricPutObject(bucket, timestamp, objectSize, cb) {
+    pushMetricPutObject(bucket, timestamp, objectSize, prevObjectSize, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
+        let numberOfObjectsCounter;
+        // if previous object size is null then it's a new object in a bucket
+        // or else it's an old object being overwritten
+        if (prevObjectSize === null) {
+            numberOfObjectsCounter = ['incr', genBucketKey(bucket,
+                'numberOfObjectsCounter')];
+        } else {
+            numberOfObjectsCounter = ['get', genBucketKey(bucket,
+                'numberOfObjectsCounter')];
+        }
+        let oldObjSize = parseInt(prevObjectSize, 10);
+        oldObjSize = isNaN(oldObjSize) ? 0 : oldObjSize;
+        let newObjSize = parseInt(objectSize, 10);
+        newObjSize = isNaN(newObjSize) ? 0 : newObjSize;
+        const storageUtilizedDelta = newObjSize - oldObjSize;
         this.log.trace('pushing metric',
             { method: 'UtapiClient.pushMetricPutObject', bucket, timestamp });
         // update counters
         return this.ds.batch([
             ['incrby', genBucketKey(bucket, 'storageUtilizedCounter'),
-                objectSize],
+                storageUtilizedDelta],
             ['incrby', genBucketKey(bucket, 'incomingBytesCounter'),
                 objectSize],
-            ['incr', genBucketKey(bucket, 'numberOfObjectsCounter')],
+            numberOfObjectsCounter,
             ['incr', genBucketKey(bucket, 'putObjectCounter')],
         ], (err, results) => {
             if (err) {

--- a/tests/functional/testUtapiClient.js
+++ b/tests/functional/testUtapiClient.js
@@ -46,7 +46,7 @@ describe('Counters', () => {
             next => utapiClient.pushMetricListBucket(testBucket, Date.now(),
                 next),
             next => utapiClient.pushMetricPutObject(testBucket, Date.now(), 8,
-                next),
+                0, next),
             next => utapiClient.pushMetricGetObject(testBucket, Date.now(), 8,
                 next),
             next => utapiClient.pushMetricDeleteObject(testBucket, Date.now(),


### PR DESCRIPTION
When an object is overwritten with new data the storage utilized counter should reflect only the total change in the size (storage + ( new size - old size ))

Fix #28 