### PR TITLE
BF: Use zrevrangebyscore to calculate nearest values

### DIFF
--- a/lib/Buckets.js
+++ b/lib/Buckets.js
@@ -1,6 +1,6 @@
 import async from 'async';
 import { errors } from 'arsenal';
-import { getMetricFromKey, getBucketKeys } from './schema';
+import { getMetricFromKey, getBucketKeys, genBucketKey } from './schema';
 
 /**
 * Provides static methods to get bucket level metrics
@@ -66,8 +66,30 @@ export default class Buckets {
     static getBucketMetrics(bucket, range, datastore, log, cb) {
         const start = range[0];
         const end = range[1] || Date.now();
-        const keys = getBucketKeys(bucket);
-        datastore.bZrangebyscore(keys, start, end, (err, res) => {
+        const storageUtilizedStart = ['zrevrangebyscore', genBucketKey(bucket,
+            'storageUtilized'), start, '-inf', 'LIMIT', '0', '1'];
+        const storageUtilizedEnd = ['zrevrangebyscore', genBucketKey(bucket,
+            'storageUtilized'), end, '-inf', 'LIMIT', '0', '1'];
+        const numberOfObjectsStart = ['zrevrangebyscore', genBucketKey(bucket,
+            'numberOfObjects'), start, '-inf', 'LIMIT', '0', '1'];
+        const numberOfObjectsEnd = ['zrevrangebyscore', genBucketKey(bucket,
+            'numberOfObjects'), end, '-inf', 'LIMIT', '0', '1'];
+        const incomingBytesStart = ['zrevrangebyscore', genBucketKey(bucket,
+            'incomingBytes'), start, '-inf', 'LIMIT', '0', '1'];
+        const incomingBytesEnd = ['zrevrangebyscore', genBucketKey(bucket,
+            'incomingBytes'), end, '-inf', 'LIMIT', '0', '1'];
+        const outgoingBytesStart = ['zrevrangebyscore', genBucketKey(bucket,
+            'outgoingBytes'), start, '-inf', 'LIMIT', '0', '1'];
+        const outgoingBytesEnd = ['zrevrangebyscore', genBucketKey(bucket,
+            'outgoingBytes'), end, '-inf', 'LIMIT', '0', '1'];
+        const bucketKeys = getBucketKeys(bucket);
+        const cmds = bucketKeys.map(item => ['zrangebyscore', item, start,
+            end]);
+        cmds.push(storageUtilizedStart, storageUtilizedEnd,
+            numberOfObjectsStart, numberOfObjectsEnd, incomingBytesStart,
+            incomingBytesEnd, outgoingBytesStart, outgoingBytesEnd);
+
+        datastore.batch(cmds, (err, res) => {
             if (err) {
                 log.trace('error occurred while getting bucket metrics', {
                     error: err,
@@ -105,6 +127,47 @@ export default class Buckets {
                     's3:HeadObject': 0,
                 },
             };
+
+            // last 8 are results of storageUtilized, numberOfObjects,
+            // incomingBytes and outgoingBytes
+            const absolutes = res.splice(-8);
+            const incomingBytes = [0, 0];
+            const outgoingBytes = [0, 0];
+            absolutes.forEach((item, index) => {
+                if (item[0]) {
+                    // log error and continue
+                    log.trace('command in a batch failed to execute', {
+                        error: item[0],
+                        method: 'Buckets.getBucketMetrics',
+                    });
+                } else {
+                    let val = parseInt(item[1], 10);
+                    val = isNaN(val) ? 0 : val;
+                    if (index === 0) {
+                        bucketRes.storageUtilized[0] = val;
+                    } else if (index === 1) {
+                        bucketRes.storageUtilized[1] = val;
+                    } else if (index === 2) {
+                        bucketRes.numberOfObjects[0] = val;
+                    } else if (index === 3) {
+                        bucketRes.numberOfObjects[1] = val;
+                    } else if (index === 4) {
+                        incomingBytes[0] = val;
+                    } else if (index === 5) {
+                        incomingBytes[1] = val;
+                    } else if (index === 6) {
+                        outgoingBytes[0] = val;
+                    } else if (index === 7) {
+                        outgoingBytes[1] = val;
+                    }
+                }
+            });
+            // calculate the delta values for incoming and outgoing bytes
+            bucketRes.incomingBytes = Math.abs(
+                incomingBytes[1] - incomingBytes[0]);
+            bucketRes.outgoingBytes = Math.abs(
+                outgoingBytes[1] - outgoingBytes[0]);
+
             /**
             * Batch result is of the format
             * [ [null, ['1', '2', '3']], [null, ['4', '5', '6']] ] where each
@@ -113,7 +176,7 @@ export default class Buckets {
             * index 1 contains the result
             */
             res.forEach((item, index) => {
-                const key = keys[index];
+                const key = bucketKeys[index];
                 if (item[0]) {
                     // log error and continue
                     log.trace('command in a batch failed to execute', {
@@ -125,20 +188,7 @@ export default class Buckets {
                     // convert strings to numbers and sort them
                     // TODO: find a efficient way to avoid sorting
                     const m = getMetricFromKey(key, bucket);
-                    if (m === 'storageUtilized' || m === 'numberOfObjects') {
-                        const values = item[1].map(v => {
-                            const tmp = parseInt(v, 10);
-                            return Number.isNaN(parseInt(v, 10)) ? 0 : tmp;
-                        });
-
-                        // pick min and max values
-                        const min = values.shift();
-                        // if max is n/a set min as max
-                        let max = values.pop();
-                        max = max === undefined ? min : max;
-                        bucketRes[m][0] = min;
-                        bucketRes[m][1] = max;
-                    } else if (m === 'incomingBytes' || m === 'outgoingBytes') {
+                    if (m === 'incomingBytes' || m === 'outgoingBytes') {
                         const values = item[1].map(v => {
                             const tmp = parseInt(v, 10);
                             return Number.isNaN(parseInt(v, 10)) ? 0 : tmp;

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -94,7 +94,13 @@ export function getBucketGlobalCounters(bucket) {
 * @return {string} - schema key
 */
 export function getBucketKeys(bucket) {
-    return Object.keys(bucketKeys).map(item => bucketKeys[item](bucket));
+    return Object.keys(bucketKeys)
+        .filter(item => item.indexOf('Counter') === -1
+            && item.indexOf('storageUtilized') === -1
+            && item.indexOf('numberOfObjects') === -1
+            && item.indexOf('incomingBytes') === -1
+            && item.indexOf('outgoingBytes') === -1)
+        .map(item => bucketKeys[item](bucket));
 }
 
 /**


### PR DESCRIPTION
Current implementation returns [0,0] for absolute counters if no
data is available in the range query. This solution searches for the
nearest values to report the absolutes

Fix #29