### PR TITLE
FT: Push metrics: normalize timestamp to the second

### DIFF
--- a/lib/UtapiClient.js
+++ b/lib/UtapiClient.js
@@ -23,6 +23,14 @@ export default class UtapiClient {
             this.disableClient = false;
         }
     }
+    /*
+    * Normalizes timestamp precision to a second instead of milliseconds to
+    * reduce the number of entries in a sorted set
+    * @return {number} timestamp normalized to the second
+    */
+    static getNomalizedTimestamp() {
+        return new Date().setMilliseconds(0);
+    }
 
     /**
     * set datastore
@@ -45,16 +53,16 @@ export default class UtapiClient {
     * bucket occcurs only once in a bucket's lifetime, counter is  always 1
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricCreateBucket(reqUid, bucket, timestamp, cb) {
+    pushMetricCreateBucket(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNomalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricCreateBucket',
             bucket, timestamp,
@@ -89,16 +97,16 @@ export default class UtapiClient {
     * Updates counter for DeleteBucket action on a Bucket resource
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricDeleteBucket(reqUid, bucket, timestamp, cb) {
+    pushMetricDeleteBucket(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNomalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricDeleteBucket',
             bucket, timestamp,
@@ -122,16 +130,16 @@ export default class UtapiClient {
     * Updates counter for ListBucket action on a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricListBucket(reqUid, bucket, timestamp, cb) {
+    pushMetricListBucket(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNomalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricListBucket',
             bucket, timestamp,
@@ -154,16 +162,16 @@ export default class UtapiClient {
     * Updates counter for GetBucketAcl action on a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricGetBucketAcl(reqUid, bucket, timestamp, cb) {
+    pushMetricGetBucketAcl(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNomalizedTimestamp();
         log.trace('pushing metric', { method: 'UtapiClient.pushMetricGet' +
             'BucketAcl',
             bucket, timestamp });
@@ -185,16 +193,16 @@ export default class UtapiClient {
     * Updates counter for PutBucketAcl action on a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricPutBucketAcl(reqUid, bucket, timestamp, cb) {
+    pushMetricPutBucketAcl(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNomalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricPutBucketAcl', bucket, timestamp });
         return this.ds.incr(genBucketKey(bucket, 'putBucketAclCounter'),
@@ -215,17 +223,17 @@ export default class UtapiClient {
     * Updates counter for UploadPart action on an object in a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {number} objectSize - size of object in bytes
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricUploadPart(reqUid, bucket, timestamp, objectSize, cb) {
+    pushMetricUploadPart(reqUid, bucket, objectSize, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNomalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricUploadPart', bucket, timestamp });
         // update counters
@@ -296,16 +304,16 @@ export default class UtapiClient {
     * Updates counter for Initiate Multipart Upload action on a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricInitiateMultipartUpload(reqUid, bucket, timestamp, cb) {
+    pushMetricInitiateMultipartUpload(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNomalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricInitiateMultipartUpload',
             bucket, timestamp,
@@ -330,16 +338,16 @@ export default class UtapiClient {
     * Updates counter for Complete Multipart Upload action on a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricCompleteMultipartUpload(reqUid, bucket, timestamp, cb) {
+    pushMetricCompleteMultipartUpload(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNomalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricCompleteMultipartUpload',
             bucket, timestamp,
@@ -396,16 +404,16 @@ export default class UtapiClient {
     * Updates counter for ListMultipartUploads action on a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricListBucketMultipartUploads(reqUid, bucket, timestamp, cb) {
+    pushMetricListBucketMultipartUploads(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNomalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricListBucketMultipartUploads',
             bucket, timestamp,
@@ -431,16 +439,16 @@ export default class UtapiClient {
     * Updates counter for ListMultipartUploadParts action on a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricListMultipartUploadParts(reqUid, bucket, timestamp, cb) {
+    pushMetricListMultipartUploadParts(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNomalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricListMultipartUploadParts',
             bucket, timestamp,
@@ -466,16 +474,16 @@ export default class UtapiClient {
     * Updates counter for AbortMultipartUpload action on a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricAbortMultipartUpload(reqUid, bucket, timestamp, cb) {
+    pushMetricAbortMultipartUpload(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNomalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricAbortMultipartUpload',
             bucket, timestamp,
@@ -500,17 +508,17 @@ export default class UtapiClient {
     * Updates counter for DeleteObject action on an object of Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {number} objectSize - size of the object
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricDeleteObject(reqUid, bucket, timestamp, objectSize, cb) {
+    pushMetricDeleteObject(reqUid, bucket, objectSize, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNomalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricDeleteObject',
             bucket, timestamp,
@@ -582,17 +590,17 @@ export default class UtapiClient {
     * Updates counter for GetObject action on an object in a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {number} objectSize - size of object in bytes
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricGetObject(reqUid, bucket, timestamp, objectSize, cb) {
+    pushMetricGetObject(reqUid, bucket, objectSize, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNomalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricGetObject', bucket, timestamp });
         // update counters
@@ -645,16 +653,16 @@ export default class UtapiClient {
     * Updates counter for GetObjectAcl action on a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricGetObjectAcl(reqUid, bucket, timestamp, cb) {
+    pushMetricGetObjectAcl(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNomalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricGetObjectAcl',
             bucket, timestamp,
@@ -678,20 +686,19 @@ export default class UtapiClient {
     * Updates counter for PutObject action on an object in a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {number} objectSize - size of object in bytes
     * @param {number} prevObjectSize - previous size of object in bytes if this
     * action overwrote an existing object
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricPutObject(reqUid, bucket, timestamp, objectSize, prevObjectSize,
-        cb) {
+    pushMetricPutObject(reqUid, bucket, objectSize, prevObjectSize, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNomalizedTimestamp();
         let numberOfObjectsCounter;
         // if previous object size is null then it's a new object in a bucket
         // or else it's an old object being overwritten
@@ -794,16 +801,16 @@ export default class UtapiClient {
     * Updates counter for PutObjectAcl action on a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricPutObjectAcl(reqUid, bucket, timestamp, cb) {
+    pushMetricPutObjectAcl(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNomalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricPutObjectAcl',
             bucket, timestamp,
@@ -826,16 +833,16 @@ export default class UtapiClient {
     * Updates counter for HeadBucket action on a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricHeadBucket(reqUid, bucket, timestamp, cb) {
+    pushMetricHeadBucket(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNomalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricHeadBucket',
             bucket, timestamp,
@@ -858,16 +865,16 @@ export default class UtapiClient {
     * Updates counter for HeadObject action on an object in a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricHeadObject(reqUid, bucket, timestamp, cb) {
+    pushMetricHeadObject(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNomalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricHeadObject',
             bucket, timestamp,

--- a/tests/functional/testUtapiClient.js
+++ b/tests/functional/testUtapiClient.js
@@ -35,27 +35,25 @@ describe('Counters', () => {
 
     it('should set global counters (other than create bucket counter) to 0 on' +
         ' bucket creation', done => {
-        const now = Date.now();
-        utapiClient.pushMetricCreateBucket(reqUid, testBucket, now,
+        utapiClient.pushMetricCreateBucket(reqUid, testBucket,
             () => _assertCounters(testBucket, done));
     });
 
     it('should reset global counters on bucket re-creation', done => {
         series([
             next => utapiClient.pushMetricCreateBucket(reqUid, testBucket,
-                Date.now(), next),
-            next => utapiClient.pushMetricListBucket(reqUid, testBucket,
-                Date.now(), next),
-            next => utapiClient.pushMetricPutObject(reqUid, testBucket,
-                Date.now(), 8, 0, next),
-            next => utapiClient.pushMetricGetObject(reqUid, testBucket,
-                Date.now(), 8, next),
-            next => utapiClient.pushMetricDeleteObject(reqUid, testBucket,
-                Date.now(), 8, next),
+                next),
+            next => utapiClient.pushMetricListBucket(reqUid, testBucket, next),
+            next => utapiClient.pushMetricPutObject(reqUid, testBucket, 8, 0,
+                next),
+            next => utapiClient.pushMetricGetObject(reqUid, testBucket, 8,
+                next),
+            next => utapiClient.pushMetricDeleteObject(reqUid, testBucket, 8,
+                next),
             next => utapiClient.pushMetricDeleteBucket(reqUid, testBucket,
-                Date.now(), next),
+                next),
             next => utapiClient.pushMetricCreateBucket(reqUid, testBucket,
-                Date.now(), next),
+                next),
         ], () => _assertCounters(testBucket, done));
     });
 });


### PR DESCRIPTION
To reduce the number of entries in the dataset, timestamp will be
normalized to the nearest second. This would mean that the metrics
will be up to date to the second and not millisecond.

Fix #32