### PR TITLE
FT: Push metrics: normalize timestamp to every 15 min

### DIFF
--- a/lib/Datastore.js
+++ b/lib/Datastore.js
@@ -125,4 +125,17 @@ export default class Datastore {
     batch(cmds, cb) {
         return this._client.pipeline(cmds).exec(cb);
     }
+
+    /**
+    * remove elements from the sorted set that fall between the min and max
+    * scores
+    * @param {string} key - key holding the value
+    * @param {number} min - integer score for start range (inclusive)
+    * @param {number} max - integer score for end range (inclusive)
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    zremrangebyscore(key, min, max, cb) {
+        return this._client.zremrangebyscore(key, min, max, cb);
+    }
 }

--- a/lib/UtapiClient.js
+++ b/lib/UtapiClient.js
@@ -25,6 +25,17 @@ export default class UtapiClient {
     }
 
     /**
+    * Normalizes timestamp precision to a 15 minutes interval to
+    * reduce the number of entries in a sorted set
+    * @return {number} timestamp normalized to the 15 minutes interval
+    */
+    static getNormalizedTimestamp() {
+        const d = new Date();
+        const minutes = d.getMinutes();
+        return d.setMinutes((minutes - minutes % 15), 0, 0);
+    }
+
+    /**
     * set datastore
     * @param {DataStore} ds - Datastore instance
     * @return {object} current instance
@@ -45,16 +56,16 @@ export default class UtapiClient {
     * bucket occcurs only once in a bucket's lifetime, counter is  always 1
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricCreateBucket(reqUid, bucket, timestamp, cb) {
+    pushMetricCreateBucket(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricCreateBucket',
             bucket, timestamp,
@@ -69,6 +80,19 @@ export default class UtapiClient {
                 cmds.push(['set', item, 0]);
             }
         });
+        cmds.push(
+            // remove old timestamp entries
+            ['zremrangebyscore', genBucketKey(bucket, 'createBucket'),
+                timestamp, timestamp],
+            ['zremrangebyscore', genBucketKey(bucket, 'storageUtilized'),
+                timestamp, timestamp],
+            ['zremrangebyscore', genBucketKey(bucket, 'numberOfObjects'),
+                timestamp, timestamp],
+            // add new timestamp entries
+            ['zadd', genBucketKey(bucket, 'createBucket'), timestamp, 1],
+            ['zadd', genBucketKey(bucket, 'storageUtilized'), timestamp, 0],
+            ['zadd', genBucketKey(bucket, 'numberOfObjects'), timestamp, 0]
+        );
         return this.ds.batch(cmds, err => {
             if (err) {
                 log.error('error incrementing counter', {
@@ -77,11 +101,7 @@ export default class UtapiClient {
                 });
                 return callback(err);
             }
-            return this.ds.batch([
-                ['zadd', genBucketKey(bucket, 'createBucket'), timestamp, 1],
-                ['zadd', genBucketKey(bucket, 'storageUtilized'), timestamp, 0],
-                ['zadd', genBucketKey(bucket, 'numberOfObjects'), timestamp, 0],
-            ], callback);
+            return callback();
         });
     }
 
@@ -89,16 +109,16 @@ export default class UtapiClient {
     * Updates counter for DeleteBucket action on a Bucket resource
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricDeleteBucket(reqUid, bucket, timestamp, cb) {
+    pushMetricDeleteBucket(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricDeleteBucket',
             bucket, timestamp,
@@ -112,8 +132,12 @@ export default class UtapiClient {
                 });
                 return callback(err);
             }
-            return this.ds.zadd(genBucketKey(bucket, 'deleteBucket'), timestamp,
-                1, callback);
+            const cmds = [
+                ['zremrangebyscore', genBucketKey(bucket, 'deleteBucket'),
+                    timestamp, timestamp],
+                ['zadd', genBucketKey(bucket, 'deleteBucket'), timestamp, 1],
+            ];
+            return this.ds.batch(cmds, callback);
         });
     }
 
@@ -122,16 +146,16 @@ export default class UtapiClient {
     * Updates counter for ListBucket action on a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricListBucket(reqUid, bucket, timestamp, cb) {
+    pushMetricListBucket(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricListBucket',
             bucket, timestamp,
@@ -145,8 +169,13 @@ export default class UtapiClient {
                     });
                     return callback(err);
                 }
-                return this.ds.zadd(genBucketKey(bucket, 'listBucket'),
-                    timestamp, count, callback);
+                const cmds = [
+                    ['zremrangebyscore', genBucketKey(bucket, 'listBucket'),
+                        timestamp, timestamp],
+                    ['zadd', genBucketKey(bucket, 'listBucket'), timestamp,
+                        count],
+                ];
+                return this.ds.batch(cmds, callback);
             });
     }
 
@@ -154,16 +183,16 @@ export default class UtapiClient {
     * Updates counter for GetBucketAcl action on a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricGetBucketAcl(reqUid, bucket, timestamp, cb) {
+    pushMetricGetBucketAcl(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', { method: 'UtapiClient.pushMetricGet' +
             'BucketAcl',
             bucket, timestamp });
@@ -176,8 +205,13 @@ export default class UtapiClient {
                     });
                     return callback(err);
                 }
-                return this.ds.zadd(genBucketKey(bucket, 'getBucketAcl'),
-                    timestamp, count, callback);
+                const cmds = [
+                    ['zremrangebyscore', genBucketKey(bucket, 'getBucketAcl'),
+                        timestamp, timestamp],
+                    ['zadd', genBucketKey(bucket, 'getBucketAcl'), timestamp,
+                        count],
+                ];
+                return this.ds.batch(cmds, callback);
             });
     }
 
@@ -185,16 +219,16 @@ export default class UtapiClient {
     * Updates counter for PutBucketAcl action on a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricPutBucketAcl(reqUid, bucket, timestamp, cb) {
+    pushMetricPutBucketAcl(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricPutBucketAcl', bucket, timestamp });
         return this.ds.incr(genBucketKey(bucket, 'putBucketAclCounter'),
@@ -206,8 +240,13 @@ export default class UtapiClient {
                     });
                     return callback(err);
                 }
-                return this.ds.zadd(genBucketKey(bucket, 'putBucketAcl'),
-                    timestamp, count, callback);
+                const cmds = [
+                    ['zremrangebyscore', genBucketKey(bucket, 'putBucketAcl'),
+                        timestamp, timestamp],
+                    ['zadd', genBucketKey(bucket, 'putBucketAcl'), timestamp,
+                        count],
+                ];
+                return this.ds.batch(cmds, callback);
             });
     }
 
@@ -215,17 +254,17 @@ export default class UtapiClient {
     * Updates counter for UploadPart action on an object in a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {number} objectSize - size of object in bytes
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricUploadPart(reqUid, bucket, timestamp, objectSize, cb) {
+    pushMetricUploadPart(reqUid, bucket, objectSize, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricUploadPart', bucket, timestamp });
         // update counters
@@ -256,9 +295,13 @@ export default class UtapiClient {
                     error: actionErr,
                 });
             } else {
-                cmds.push(['zadd',
-                    genBucketKey(bucket, 'storageUtilized'), timestamp,
-                        actionCounter]);
+                cmds.push(
+                    ['zremrangebyscore',
+                        genBucketKey(bucket, 'storageUtilized'), timestamp,
+                        timestamp],
+                    ['zadd', genBucketKey(bucket, 'storageUtilized'), timestamp,
+                        actionCounter]
+                );
             }
 
             // incoming bytes counter
@@ -271,9 +314,11 @@ export default class UtapiClient {
                     error: actionErr,
                 });
             } else {
-                cmds.push(['zadd',
-                    genBucketKey(bucket, 'incomingBytes'),
-                    timestamp, actionCounter]);
+                cmds.push(
+                    ['zremrangebyscore', genBucketKey(bucket, 'incomingBytes'),
+                        timestamp, timestamp],
+                    ['zadd', genBucketKey(bucket, 'incomingBytes'), timestamp,
+                        actionCounter]);
             }
             // uploadPart counter
             actionErr = results[2][0];
@@ -285,8 +330,11 @@ export default class UtapiClient {
                     error: actionErr,
                 });
             } else {
-                cmds.push(['zadd', genBucketKey(bucket, 'uploadPart'),
-                    timestamp, actionCounter]);
+                cmds.push(
+                    ['zremrangebyscore', genBucketKey(bucket, 'uploadPart'),
+                        timestamp, timestamp],
+                    ['zadd', genBucketKey(bucket, 'uploadPart'), timestamp,
+                        actionCounter]);
             }
             return this.ds.batch(cmds, callback);
         });
@@ -296,16 +344,16 @@ export default class UtapiClient {
     * Updates counter for Initiate Multipart Upload action on a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricInitiateMultipartUpload(reqUid, bucket, timestamp, cb) {
+    pushMetricInitiateMultipartUpload(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricInitiateMultipartUpload',
             bucket, timestamp,
@@ -320,9 +368,14 @@ export default class UtapiClient {
                     });
                     return callback(err);
                 }
-                return this.ds.zadd(
-                    genBucketKey(bucket, 'initiateMultipartUpload'),
-                    timestamp, count, callback);
+                const cmds = [
+                    ['zremrangebyscore',
+                        genBucketKey(bucket, 'initiateMultipartUpload'),
+                        timestamp, timestamp],
+                    ['zadd', genBucketKey(bucket, 'initiateMultipartUpload'),
+                        timestamp, count],
+                ];
+                return this.ds.batch(cmds, callback);
             });
     }
 
@@ -330,16 +383,16 @@ export default class UtapiClient {
     * Updates counter for Complete Multipart Upload action on a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricCompleteMultipartUpload(reqUid, bucket, timestamp, cb) {
+    pushMetricCompleteMultipartUpload(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricCompleteMultipartUpload',
             bucket, timestamp,
@@ -370,8 +423,12 @@ export default class UtapiClient {
                     error: actionErr,
                 });
             } else {
-                cmds.push(['zadd', genBucketKey(bucket, 'numberOfObjects'),
-                    timestamp, actionCounter]);
+                cmds.push(
+                    ['zremrangebyscore',
+                        genBucketKey(bucket, 'numberOfObjects'), timestamp,
+                        timestamp],
+                    ['zadd', genBucketKey(bucket, 'numberOfObjects'),
+                        timestamp, actionCounter]);
             }
 
             // completeMultipartUpload counter
@@ -384,9 +441,13 @@ export default class UtapiClient {
                     error: actionErr,
                 });
             } else {
-                cmds.push(['zadd',
-                    genBucketKey(bucket, 'completeMultipartUpload'),
-                    timestamp, actionCounter]);
+                cmds.push(
+                    ['zremrangebyscore',
+                        genBucketKey(bucket, 'completeMultipartUpload'),
+                        timestamp, timestamp],
+                    ['zadd',
+                        genBucketKey(bucket, 'completeMultipartUpload'),
+                        timestamp, actionCounter]);
             }
             return this.ds.batch(cmds, callback);
         });
@@ -396,16 +457,16 @@ export default class UtapiClient {
     * Updates counter for ListMultipartUploads action on a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricListBucketMultipartUploads(reqUid, bucket, timestamp, cb) {
+    pushMetricListBucketMultipartUploads(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricListBucketMultipartUploads',
             bucket, timestamp,
@@ -421,9 +482,14 @@ export default class UtapiClient {
                     });
                     return callback(err);
                 }
-                return this.ds.zadd(
-                    genBucketKey(bucket, 'listBucketMultipartUploads'),
-                    timestamp, count, callback);
+                const cmds = [
+                    ['zremrangebyscore',
+                        genBucketKey(bucket, 'listBucketMultipartUploads'),
+                        timestamp, timestamp],
+                    ['zadd', genBucketKey(bucket, 'listBucketMultipartUploads'),
+                        timestamp, count],
+                ];
+                return this.ds.batch(cmds, callback);
             });
     }
 
@@ -431,16 +497,16 @@ export default class UtapiClient {
     * Updates counter for ListMultipartUploadParts action on a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricListMultipartUploadParts(reqUid, bucket, timestamp, cb) {
+    pushMetricListMultipartUploadParts(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricListMultipartUploadParts',
             bucket, timestamp,
@@ -456,9 +522,14 @@ export default class UtapiClient {
                     });
                     return callback(err);
                 }
-                return this.ds.zadd(
-                    genBucketKey(bucket, 'listMultipartUploadParts'),
-                    timestamp, count, callback);
+                const cmds = [
+                    ['zremrangebyscore',
+                        genBucketKey(bucket, 'listMultipartUploadParts'),
+                        timestamp, timestamp],
+                    ['zadd', genBucketKey(bucket, 'listMultipartUploadParts'),
+                        timestamp, count],
+                ];
+                return this.ds.batch(cmds, callback);
             });
     }
 
@@ -466,16 +537,16 @@ export default class UtapiClient {
     * Updates counter for AbortMultipartUpload action on a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricAbortMultipartUpload(reqUid, bucket, timestamp, cb) {
+    pushMetricAbortMultipartUpload(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricAbortMultipartUpload',
             bucket, timestamp,
@@ -490,9 +561,14 @@ export default class UtapiClient {
                     });
                     return callback(err);
                 }
-                return this.ds.zadd(
-                    genBucketKey(bucket, 'abortMultipartUpload'),
-                    timestamp, count, callback);
+                const cmds = [
+                    ['zremrangebyscore',
+                        genBucketKey(bucket, 'abortMultipartUpload'), timestamp,
+                        timestamp],
+                    ['zadd', genBucketKey(bucket, 'abortMultipartUpload'),
+                        timestamp, count],
+                ];
+                return this.ds.batch(cmds, callback);
             });
     }
 
@@ -500,17 +576,17 @@ export default class UtapiClient {
     * Updates counter for DeleteObject action on an object of Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {number} objectSize - size of the object
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricDeleteObject(reqUid, bucket, timestamp, objectSize, cb) {
+    pushMetricDeleteObject(reqUid, bucket, objectSize, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricDeleteObject',
             bucket, timestamp,
@@ -542,8 +618,12 @@ export default class UtapiClient {
                     error: actionErr,
                 });
             } else {
-                cmds.push(['zadd', genBucketKey(bucket, 'storageUtilized'),
-                    timestamp, tempCounter]);
+                cmds.push(
+                    ['zremrangebyscore',
+                        genBucketKey(bucket, 'storageUtilized'), timestamp,
+                        timestamp],
+                    ['zadd', genBucketKey(bucket, 'storageUtilized'),
+                        timestamp, tempCounter]);
             }
 
             // del object counter
@@ -556,8 +636,11 @@ export default class UtapiClient {
                     error: actionErr,
                 });
             } else {
-                cmds.push(['zadd', genBucketKey(bucket, 'deleteObject'),
-                 timestamp, actionCounter]);
+                cmds.push(
+                    ['zremrangebyscore', genBucketKey(bucket, 'deleteObject'),
+                        timestamp, timestamp],
+                    ['zadd', genBucketKey(bucket, 'deleteObject'),
+                        timestamp, actionCounter]);
             }
 
             // num of objects counter
@@ -571,7 +654,11 @@ export default class UtapiClient {
                     error: actionErr,
                 });
             } else {
-                cmds.push(['zadd', genBucketKey(bucket, 'numberOfObjects'),
+                cmds.push(
+                    ['zremrangebyscore',
+                        genBucketKey(bucket, 'numberOfObjects'), timestamp,
+                        timestamp],
+                    ['zadd', genBucketKey(bucket, 'numberOfObjects'),
                  timestamp, tempCounter]);
             }
             return this.ds.batch(cmds, callback);
@@ -582,17 +669,17 @@ export default class UtapiClient {
     * Updates counter for GetObject action on an object in a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {number} objectSize - size of object in bytes
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricGetObject(reqUid, bucket, timestamp, objectSize, cb) {
+    pushMetricGetObject(reqUid, bucket, objectSize, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricGetObject', bucket, timestamp });
         // update counters
@@ -619,9 +706,11 @@ export default class UtapiClient {
                     error: actionErr,
                 });
             } else {
-                cmds.push(['zadd',
-                    genBucketKey(bucket, 'outgoingBytes'),
-                    timestamp, actionCounter]);
+                cmds.push(
+                    ['zremrangebyscore', genBucketKey(bucket, 'outgoingBytes'),
+                        timestamp, timestamp],
+                    ['zadd', genBucketKey(bucket, 'outgoingBytes'), timestamp,
+                        actionCounter]);
             }
 
             // get object counter
@@ -634,8 +723,11 @@ export default class UtapiClient {
                     error: actionErr,
                 });
             } else {
-                cmds.push(['zadd', genBucketKey(bucket, 'getObject'), timestamp,
-                    actionCounter]);
+                cmds.push(
+                    ['zremrangebyscore', genBucketKey(bucket, 'getObject'),
+                        timestamp, timestamp],
+                    ['zadd', genBucketKey(bucket, 'getObject'), timestamp,
+                        actionCounter]);
             }
             return this.ds.batch(cmds, callback);
         });
@@ -645,16 +737,16 @@ export default class UtapiClient {
     * Updates counter for GetObjectAcl action on a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricGetObjectAcl(reqUid, bucket, timestamp, cb) {
+    pushMetricGetObjectAcl(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricGetObjectAcl',
             bucket, timestamp,
@@ -668,8 +760,13 @@ export default class UtapiClient {
                     });
                     return callback(err);
                 }
-                return this.ds.zadd(genBucketKey(bucket, 'getObjectAcl'),
-                    timestamp, count, callback);
+                const cmds = [
+                    ['zremrangebyscore', genBucketKey(bucket, 'getObjectAcl'),
+                        timestamp, timestamp],
+                    ['zadd', genBucketKey(bucket, 'getObjectAcl'), timestamp,
+                        count],
+                ];
+                return this.ds.batch(cmds, callback);
             });
     }
 
@@ -678,20 +775,19 @@ export default class UtapiClient {
     * Updates counter for PutObject action on an object in a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {number} objectSize - size of object in bytes
     * @param {number} prevObjectSize - previous size of object in bytes if this
     * action overwrote an existing object
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricPutObject(reqUid, bucket, timestamp, objectSize, prevObjectSize,
-        cb) {
+    pushMetricPutObject(reqUid, bucket, objectSize, prevObjectSize, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         let numberOfObjectsCounter;
         // if previous object size is null then it's a new object in a bucket
         // or else it's an old object being overwritten
@@ -738,9 +834,12 @@ export default class UtapiClient {
                     error: actionErr,
                 });
             } else {
-                cmds.push(['zadd',
-                    genBucketKey(bucket, 'storageUtilized'),
-                    timestamp, actionCounter]);
+                cmds.push(
+                    ['zremrangebyscore',
+                        genBucketKey(bucket, 'storageUtilized'), timestamp,
+                        timestamp],
+                    ['zadd', genBucketKey(bucket, 'storageUtilized'), timestamp,
+                    actionCounter]);
             }
 
             // incoming bytes counter
@@ -753,9 +852,11 @@ export default class UtapiClient {
                     error: actionErr,
                 });
             } else {
-                cmds.push(['zadd',
-                    genBucketKey(bucket, 'incomingBytes'),
-                    timestamp, actionCounter]);
+                cmds.push(
+                    ['zremrangebyscore', genBucketKey(bucket, 'incomingBytes'),
+                        timestamp, timestamp],
+                    ['zadd', genBucketKey(bucket, 'incomingBytes'), timestamp,
+                        actionCounter]);
             }
 
             // number of objects counter
@@ -768,8 +869,11 @@ export default class UtapiClient {
                     error: actionErr,
                 });
             } else {
-                cmds.push(['zadd',
-                    genBucketKey(bucket, 'numberOfObjects'), timestamp,
+                cmds.push(
+                    ['zremrangebyscore',
+                        genBucketKey(bucket, 'numberOfObjects'), timestamp,
+                        timestamp],
+                    ['zadd', genBucketKey(bucket, 'numberOfObjects'), timestamp,
                     actionCounter]);
             }
 
@@ -783,7 +887,10 @@ export default class UtapiClient {
                     error: actionErr,
                 });
             } else {
-                cmds.push(['zadd', genBucketKey(bucket, 'putObject'), timestamp,
+                cmds.push(
+                    ['zremrangebyscore', genBucketKey(bucket, 'putObject'),
+                        timestamp, timestamp],
+                    ['zadd', genBucketKey(bucket, 'putObject'), timestamp,
                     actionCounter]);
             }
             return this.ds.batch(cmds, callback);
@@ -794,16 +901,16 @@ export default class UtapiClient {
     * Updates counter for PutObjectAcl action on a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricPutObjectAcl(reqUid, bucket, timestamp, cb) {
+    pushMetricPutObjectAcl(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricPutObjectAcl',
             bucket, timestamp,
@@ -817,8 +924,13 @@ export default class UtapiClient {
                     });
                     return callback(err);
                 }
-                return this.ds.zadd(genBucketKey(bucket, 'putObjectAcl'),
-                    timestamp, count, callback);
+                const cmds = [
+                    ['zremrangebyscore', genBucketKey(bucket, 'putObjectAcl'),
+                        timestamp, timestamp],
+                    ['zadd', genBucketKey(bucket, 'putObjectAcl'), timestamp,
+                        count],
+                ];
+                return this.ds.batch(cmds, callback);
             });
     }
 
@@ -826,16 +938,16 @@ export default class UtapiClient {
     * Updates counter for HeadBucket action on a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricHeadBucket(reqUid, bucket, timestamp, cb) {
+    pushMetricHeadBucket(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricHeadBucket',
             bucket, timestamp,
@@ -849,8 +961,13 @@ export default class UtapiClient {
                     });
                     return callback(err);
                 }
-                return this.ds.zadd(genBucketKey(bucket, 'headBucket'),
-                    timestamp, count, callback);
+                const cmds = [
+                    ['zremrangebyscore', genBucketKey(bucket, 'headBucket'),
+                        timestamp, timestamp],
+                    ['zadd', genBucketKey(bucket, 'headBucket'), timestamp,
+                        count],
+                ];
+                return this.ds.batch(cmds, callback);
             });
     }
 
@@ -858,16 +975,16 @@ export default class UtapiClient {
     * Updates counter for HeadObject action on an object in a Bucket resource.
     * @param {string} reqUid - Request Unique Identifier
     * @param {string} bucket - bucket name
-    * @param {number} timestamp - unix epoch timestamp
     * @param {callback} [cb] - (optional) callback to call
     * @return {undefined}
     */
-    pushMetricHeadObject(reqUid, bucket, timestamp, cb) {
+    pushMetricHeadObject(reqUid, bucket, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricHeadObject',
             bucket, timestamp,
@@ -881,8 +998,13 @@ export default class UtapiClient {
                     });
                     return callback(err);
                 }
-                return this.ds.zadd(genBucketKey(bucket, 'headObject'),
-                    timestamp, count, callback);
+                const cmds = [
+                    ['zremrangebyscore', genBucketKey(bucket, 'headObject'),
+                        timestamp, timestamp],
+                    ['zadd', genBucketKey(bucket, 'headObject'), timestamp,
+                        count],
+                ];
+                return this.ds.batch(cmds, callback);
             });
     }
 }

--- a/lib/backend/Memory.js
+++ b/lib/backend/Memory.js
@@ -222,6 +222,35 @@ export default class Memory {
     }
 
     /**
+    * Remove elements from sorted set at key with scores between min and
+    * max (all inclusive)
+    * @param {string} key - data key
+    * @param {string|number} min - min score (number or -inf)
+    * @param {string|number} max - max score (number or +inf)
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    zremrangebyscore(key, min, max, cb) {
+        process.nextTick(() => {
+            if (!this.data[key]) {
+                // emulating redis-client which returns nulls
+                return cb(null, null);
+            }
+            const minScore = (min === '-inf') ? this.data[key][0][0] : min;
+            const maxScore = (min === '+inf') ?
+                this.data[key][this.data[key].length][0] : max;
+            let removeCount = 0;
+            this.data[key].forEach((item, index) => {
+                if (item[0] >= minScore && item[0] <= maxScore) {
+                    this.data[key].splice(index, 1);
+                    removeCount++;
+                }
+            });
+            return cb(null, removeCount);
+        });
+    }
+
+    /**
     * Returns a pipeline instance that can execute commmands as a batch
     * @param {array} cmds - list of commands
     * @return {Pipeline} - Pipeline instance

--- a/tests/functional/testUtapiClient.js
+++ b/tests/functional/testUtapiClient.js
@@ -35,27 +35,25 @@ describe('Counters', () => {
 
     it('should set global counters (other than create bucket counter) to 0 on' +
         ' bucket creation', done => {
-        const now = Date.now();
-        utapiClient.pushMetricCreateBucket(reqUid, testBucket, now,
+        utapiClient.pushMetricCreateBucket(reqUid, testBucket,
             () => _assertCounters(testBucket, done));
     });
 
     it('should reset global counters on bucket re-creation', done => {
         series([
             next => utapiClient.pushMetricCreateBucket(reqUid, testBucket,
-                Date.now(), next),
-            next => utapiClient.pushMetricListBucket(reqUid, testBucket,
-                Date.now(), next),
-            next => utapiClient.pushMetricPutObject(reqUid, testBucket,
-                Date.now(), 8, 0, next),
-            next => utapiClient.pushMetricGetObject(reqUid, testBucket,
-                Date.now(), 8, next),
-            next => utapiClient.pushMetricDeleteObject(reqUid, testBucket,
-                Date.now(), 8, next),
+                next),
+            next => utapiClient.pushMetricListBucket(reqUid, testBucket, next),
+            next => utapiClient.pushMetricPutObject(reqUid, testBucket, 8, 0,
+                next),
+            next => utapiClient.pushMetricGetObject(reqUid, testBucket, 8,
+                next),
+            next => utapiClient.pushMetricDeleteObject(reqUid, testBucket, 8,
+                next),
             next => utapiClient.pushMetricDeleteBucket(reqUid, testBucket,
-                Date.now(), next),
+                next),
             next => utapiClient.pushMetricCreateBucket(reqUid, testBucket,
-                Date.now(), next),
+                next),
         ], () => _assertCounters(testBucket, done));
     });
 });


### PR DESCRIPTION
To reduce the number of entries in the dataset, timestamp will be
normalized to 15 minute intervals. This would mean that the metrics
will be up to date to the 15 minute interval and not millisecond.

Fix #32