### PR TITLE
FT: Shard datasets by the day

### DIFF
--- a/lib/Buckets.js
+++ b/lib/Buckets.js
@@ -1,6 +1,7 @@
 import async from 'async';
 import { errors } from 'arsenal';
-import { getMetricFromKey, getBucketKeys, genBucketKey } from './schema';
+import { getMetricFromKey, getBucketKeys, genBucketStateKey } from './schema';
+import getTimespan from '../utils/getTimespan';
 
 /**
 * Provides static methods to get bucket level metrics
@@ -31,6 +32,25 @@ export default class Buckets {
             Buckets.getBucketMetrics(bucket, timeRange, datastore, log, next),
             cb
         );
+    }
+
+    /**
+    * Returns a list of timestamps incremented by a day starting from start
+    * to end
+    * @param {number} start - start timestamp
+    * @param {number} end - end timestamp
+    * @return {number[]} range - array of timestamps
+    */
+    static getTimespanRange(start, end) {
+        const res = [];
+        let last = start;
+        while (last !== end) {
+            res.push(last);
+            const d = new Date(last);
+            last = d.setDate(d.getDate() + 1);
+        }
+        res.push(end);
+        return res;
     }
 
     /**
@@ -65,24 +85,31 @@ export default class Buckets {
     */
     static getBucketMetrics(bucket, range, datastore, log, cb) {
         const start = range[0];
+        const startspan = getTimespan(start);
         const end = range[1] || Date.now();
-        const storageUtilizedStart = ['zrevrangebyscore', genBucketKey(bucket,
-            'storageUtilized'), start, '-inf', 'LIMIT', '0', '1'];
-        const storageUtilizedEnd = ['zrevrangebyscore', genBucketKey(bucket,
-            'storageUtilized'), end, '-inf', 'LIMIT', '0', '1'];
-        const numberOfObjectsStart = ['zrevrangebyscore', genBucketKey(bucket,
-            'numberOfObjects'), start, '-inf', 'LIMIT', '0', '1'];
-        const numberOfObjectsEnd = ['zrevrangebyscore', genBucketKey(bucket,
-            'numberOfObjects'), end, '-inf', 'LIMIT', '0', '1'];
-        const incomingBytesStart = ['zrevrangebyscore', genBucketKey(bucket,
-            'incomingBytes'), start, '-inf', 'LIMIT', '0', '1'];
-        const incomingBytesEnd = ['zrevrangebyscore', genBucketKey(bucket,
-            'incomingBytes'), end, '-inf', 'LIMIT', '0', '1'];
-        const outgoingBytesStart = ['zrevrangebyscore', genBucketKey(bucket,
-            'outgoingBytes'), start, '-inf', 'LIMIT', '0', '1'];
-        const outgoingBytesEnd = ['zrevrangebyscore', genBucketKey(bucket,
-            'outgoingBytes'), end, '-inf', 'LIMIT', '0', '1'];
-        const bucketKeys = getBucketKeys(bucket);
+        const endspan = getTimespan(end);
+        const storageUtilizedKey = genBucketStateKey(bucket, 'storageUtilized');
+        const numberOfObjectsKey = genBucketStateKey(bucket, 'numberOfObjects');
+        const incomingBytesKey = genBucketStateKey(bucket, 'incomingBytes');
+        const outgoingBytesKey = genBucketStateKey(bucket, 'outgoingBytes');
+        const storageUtilizedStart = ['zrevrangebyscore', storageUtilizedKey,
+            start, '-inf', 'LIMIT', '0', '1'];
+        const storageUtilizedEnd = ['zrevrangebyscore', storageUtilizedKey, end,
+            '-inf', 'LIMIT', '0', '1'];
+        const numberOfObjectsStart = ['zrevrangebyscore', numberOfObjectsKey,
+            start, '-inf', 'LIMIT', '0', '1'];
+        const numberOfObjectsEnd = ['zrevrangebyscore', numberOfObjectsKey, end,
+            '-inf', 'LIMIT', '0', '1'];
+        const incomingBytesStart = ['zrevrangebyscore', incomingBytesKey,
+            start, '-inf', 'LIMIT', '0', '1'];
+        const incomingBytesEnd = ['zrevrangebyscore', incomingBytesKey, end,
+            '-inf', 'LIMIT', '0', '1'];
+        const outgoingBytesStart = ['zrevrangebyscore', outgoingBytesKey, start,
+            '-inf', 'LIMIT', '0', '1'];
+        const outgoingBytesEnd = ['zrevrangebyscore', outgoingBytesKey, end,
+            '-inf', 'LIMIT', '0', '1'];
+        const timespanRange = Buckets.getTimespanRange(startspan, endspan);
+        const bucketKeys = timespanRange.map(i => getBucketKeys(bucket, i));
         const cmds = bucketKeys.map(item => ['zrangebyscore', item, start,
             end]);
         cmds.push(storageUtilizedStart, storageUtilizedEnd,
@@ -184,26 +211,12 @@ export default class Buckets {
                         method: 'Buckets.getBucketMetrics',
                         cmd: key,
                     });
-                } else if (item[1].length > 0) {
-                    // convert strings to numbers and sort them
-                    // TODO: find a efficient way to avoid sorting
+                } else if (Array.isArray(item[1])) {
+                    // convert strings to numbers for comparision
                     const m = getMetricFromKey(key, bucket);
-                    if (m === 'incomingBytes' || m === 'outgoingBytes') {
-                        const values = item[1].map(v => {
-                            const tmp = parseInt(v, 10);
-                            return Number.isNaN(parseInt(v, 10)) ? 0 : tmp;
-                        });
-
-                        // pick min and max values
-                        const min = values.shift();
-                        // if max is n/a set min as max
-                        const max = values.pop() || min;
-                        bucketRes[m] = max;
-                    } else {
-                        // count is enough as it represents the delta of the
-                        // metric between the two timestamps
-                        bucketRes.operations[`s3:${m}`] = item[1].length || 0;
-                    }
+                    // count is enough as it represents the delta of the
+                    // metric between the two timestamps
+                    bucketRes.operations[`s3:${m}`] += item[1].length || 0;
                 }
             });
             return cb(null, bucketRes);

--- a/lib/UtapiClient.js
+++ b/lib/UtapiClient.js
@@ -1,6 +1,7 @@
 import { Logger } from 'werelogs';
 import Datastore from './Datastore';
-import { genBucketKey, getBucketGlobalCounters } from './schema';
+import { genBucketKey, genBucketCounter, getBucketCounters, genBucketStateKey }
+    from './schema';
 import redisClient from '../utils/redisClient';
 
 export default class UtapiClient {
@@ -27,12 +28,17 @@ export default class UtapiClient {
     /**
     * Normalizes timestamp precision to a 15 minutes interval to
     * reduce the number of entries in a sorted set
-    * @return {number} timestamp normalized to the 15 minutes interval
+    * @return {object} normalizedTime - normalized time
+    * @property {number} normalizedTime.timestamp - normalized to the
+    * nearest 15 minutes interval
+    * @property {number} normalizedTime.timespan - normalized to the date
     */
-    static getNormalizedTimestamp() {
+    static getNormalizedTime() {
         const d = new Date();
         const minutes = d.getMinutes();
-        return d.setMinutes((minutes - minutes % 15), 0, 0);
+        const timestamp = d.setMinutes((minutes - minutes % 15), 0, 0);
+        const timespan = d.setHours(0, 0);
+        return { timestamp, timespan };
     }
 
     /**
@@ -65,15 +71,15 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricCreateBucket',
             bucket, timestamp,
         });
         const cmds = [];
-        // set global counters to 0 except for create bucket counter (set to 1)
+        // set counters to 0 except for create bucket counter (set to 1)
         // indicating start of bucket timeline
-        getBucketGlobalCounters(bucket).forEach(item => {
+        getBucketCounters(bucket).forEach(item => {
             if (item.indexOf('CreateBucket:counter') !== -1) {
                 cmds.push(['set', item, 1]);
             } else {
@@ -82,16 +88,19 @@ export default class UtapiClient {
         });
         cmds.push(
             // remove old timestamp entries
-            ['zremrangebyscore', genBucketKey(bucket, 'createBucket'),
+            ['zremrangebyscore', genBucketKey(bucket, 'createBucket', timespan),
                 timestamp, timestamp],
-            ['zremrangebyscore', genBucketKey(bucket, 'storageUtilized'),
-                timestamp, timestamp],
-            ['zremrangebyscore', genBucketKey(bucket, 'numberOfObjects'),
+            ['zremrangebyscore',
+                genBucketStateKey(bucket, 'storageUtilized'), timestamp,
+                timestamp],
+            ['zremrangebyscore', genBucketStateKey(bucket, 'numberOfObjects'),
                 timestamp, timestamp],
             // add new timestamp entries
-            ['zadd', genBucketKey(bucket, 'createBucket'), timestamp, 1],
-            ['zadd', genBucketKey(bucket, 'storageUtilized'), timestamp, 0],
-            ['zadd', genBucketKey(bucket, 'numberOfObjects'), timestamp, 0]
+            ['zadd', genBucketKey(bucket, 'createBucket', timespan), timestamp,
+                1],
+            ['zadd', genBucketStateKey(bucket, 'storageUtilized'), timestamp,
+                0],
+            ['zadd', genBucketStateKey(bucket, 'numberOfObjects'), timestamp, 0]
         );
         return this.ds.batch(cmds, err => {
             if (err) {
@@ -118,12 +127,12 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricDeleteBucket',
             bucket, timestamp,
         });
-        const key = genBucketKey(bucket, 'deleteBucketCounter');
+        const key = genBucketCounter(bucket, 'deleteBucketCounter');
         return this.ds.set(key, 1, err => {
             if (err) {
                 log.error('error incrementing counter', {
@@ -133,9 +142,11 @@ export default class UtapiClient {
                 return callback(err);
             }
             const cmds = [
-                ['zremrangebyscore', genBucketKey(bucket, 'deleteBucket'),
-                    timestamp, timestamp],
-                ['zadd', genBucketKey(bucket, 'deleteBucket'), timestamp, 1],
+                ['zremrangebyscore',
+                    genBucketKey(bucket, 'deleteBucket', timespan), timestamp,
+                    timestamp],
+                ['zadd', genBucketKey(bucket, 'deleteBucket', timespan),
+                    timestamp, 1],
             ];
             return this.ds.batch(cmds, callback);
         });
@@ -155,12 +166,12 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricListBucket',
             bucket, timestamp,
         });
-        return this.ds.incr(genBucketKey(bucket, 'listBucketCounter'),
+        return this.ds.incr(genBucketCounter(bucket, 'listBucketCounter'),
             (err, count) => {
                 if (err) {
                     log.error('error incrementing counter', {
@@ -170,10 +181,11 @@ export default class UtapiClient {
                     return callback(err);
                 }
                 const cmds = [
-                    ['zremrangebyscore', genBucketKey(bucket, 'listBucket'),
-                        timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'listBucket'), timestamp,
-                        count],
+                    ['zremrangebyscore',
+                        genBucketKey(bucket, 'listBucket', timespan), timestamp,
+                        timestamp],
+                    ['zadd', genBucketKey(bucket, 'listBucket', timespan),
+                        timestamp, count],
                 ];
                 return this.ds.batch(cmds, callback);
             });
@@ -192,27 +204,28 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
         log.trace('pushing metric', { method: 'UtapiClient.pushMetricGet' +
             'BucketAcl',
             bucket, timestamp });
-        return this.ds.incr(genBucketKey(bucket, 'getBucketAclCounter'),
-            (err, count) => {
-                if (err) {
-                    log.error('error incrementing counter', {
-                        method: 'Buckets.pushMetricGetBucketAcl',
-                        error: err,
-                    });
-                    return callback(err);
-                }
-                const cmds = [
-                    ['zremrangebyscore', genBucketKey(bucket, 'getBucketAcl'),
-                        timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'getBucketAcl'), timestamp,
-                        count],
-                ];
-                return this.ds.batch(cmds, callback);
-            });
+        const key = genBucketCounter(bucket, 'getBucketAclCounter');
+        return this.ds.incr(key, (err, count) => {
+            if (err) {
+                log.error('error incrementing counter', {
+                    method: 'Buckets.pushMetricGetBucketAcl',
+                    error: err,
+                });
+                return callback(err);
+            }
+            const cmds = [
+                ['zremrangebyscore',
+                    genBucketKey(bucket, 'getBucketAcl', timespan), timestamp,
+                    timestamp],
+                ['zadd', genBucketKey(bucket, 'getBucketAcl', timespan),
+                    timestamp, count],
+            ];
+            return this.ds.batch(cmds, callback);
+        });
     }
 
     /**
@@ -228,26 +241,27 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricPutBucketAcl', bucket, timestamp });
-        return this.ds.incr(genBucketKey(bucket, 'putBucketAclCounter'),
-            (err, count) => {
-                if (err) {
-                    log.error('error incrementing counter', {
-                        method: 'Buckets.pushMetricPutBucketAcl',
-                        error: err,
-                    });
-                    return callback(err);
-                }
-                const cmds = [
-                    ['zremrangebyscore', genBucketKey(bucket, 'putBucketAcl'),
-                        timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'putBucketAcl'), timestamp,
-                        count],
-                ];
-                return this.ds.batch(cmds, callback);
-            });
+        const key = genBucketCounter(bucket, 'putBucketAclCounter');
+        return this.ds.incr(key, (err, count) => {
+            if (err) {
+                log.error('error incrementing counter', {
+                    method: 'Buckets.pushMetricPutBucketAcl',
+                    error: err,
+                });
+                return callback(err);
+            }
+            const cmds = [
+                ['zremrangebyscore',
+                    genBucketKey(bucket, 'putBucketAcl', timespan),
+                    timestamp, timestamp],
+                ['zadd', genBucketKey(bucket, 'putBucketAcl', timespan),
+                    timestamp, count],
+            ];
+            return this.ds.batch(cmds, callback);
+        });
     }
 
     /**
@@ -264,16 +278,16 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricUploadPart', bucket, timestamp });
         // update counters
         return this.ds.batch([
-            ['incrby', genBucketKey(bucket, 'storageUtilizedCounter'),
+            ['incrby', genBucketCounter(bucket, 'storageUtilizedCounter'),
                 objectSize],
-            ['incrby', genBucketKey(bucket, 'incomingBytesCounter'),
+            ['incrby', genBucketCounter(bucket, 'incomingBytesCounter'),
                 objectSize],
-            ['incr', genBucketKey(bucket, 'uploadPartCounter')],
+            ['incr', genBucketCounter(bucket, 'uploadPartCounter')],
         ], (err, results) => {
             if (err) {
                 log.error('error pushing metric', {
@@ -297,10 +311,11 @@ export default class UtapiClient {
             } else {
                 cmds.push(
                     ['zremrangebyscore',
-                        genBucketKey(bucket, 'storageUtilized'), timestamp,
-                        timestamp],
-                    ['zadd', genBucketKey(bucket, 'storageUtilized'), timestamp,
-                        actionCounter]
+                        genBucketStateKey(bucket, 'storageUtilized'),
+                        timestamp, timestamp],
+                    ['zadd',
+                        genBucketStateKey(bucket, 'storageUtilized'),
+                        timestamp, actionCounter]
                 );
             }
 
@@ -315,10 +330,11 @@ export default class UtapiClient {
                 });
             } else {
                 cmds.push(
-                    ['zremrangebyscore', genBucketKey(bucket, 'incomingBytes'),
+                    ['zremrangebyscore',
+                        genBucketStateKey(bucket, 'incomingBytes'),
                         timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'incomingBytes'), timestamp,
-                        actionCounter]);
+                    ['zadd', genBucketStateKey(bucket, 'incomingBytes'),
+                        timestamp, actionCounter]);
             }
             // uploadPart counter
             actionErr = results[2][0];
@@ -331,10 +347,11 @@ export default class UtapiClient {
                 });
             } else {
                 cmds.push(
-                    ['zremrangebyscore', genBucketKey(bucket, 'uploadPart'),
+                    ['zremrangebyscore',
+                        genBucketKey(bucket, 'uploadPart', timespan),
                         timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'uploadPart'), timestamp,
-                        actionCounter]);
+                    ['zadd', genBucketKey(bucket, 'uploadPart', timespan),
+                        timestamp, actionCounter]);
             }
             return this.ds.batch(cmds, callback);
         });
@@ -353,30 +370,30 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricInitiateMultipartUpload',
             bucket, timestamp,
         });
-        return this.ds.incr(
-            genBucketKey(bucket, 'initiateMultipartUploadCounter'),
-            (err, count) => {
-                if (err) {
-                    log.error('error incrementing counter', {
-                        method: 'UtapiClient.pushMetricInitiateMultipartUpload',
-                        error: err,
-                    });
-                    return callback(err);
-                }
-                const cmds = [
-                    ['zremrangebyscore',
-                        genBucketKey(bucket, 'initiateMultipartUpload'),
-                        timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'initiateMultipartUpload'),
-                        timestamp, count],
-                ];
-                return this.ds.batch(cmds, callback);
-            });
+        const key = genBucketCounter(bucket, 'initiateMultipartUploadCounter');
+        return this.ds.incr(key, (err, count) => {
+            if (err) {
+                log.error('error incrementing counter', {
+                    method: 'UtapiClient.pushMetricInitiateMultipartUpload',
+                    error: err,
+                });
+                return callback(err);
+            }
+            const cmds = [
+                ['zremrangebyscore',
+                    genBucketKey(bucket, 'initiateMultipartUpload', timespan),
+                    timestamp, timestamp],
+                ['zadd',
+                    genBucketKey(bucket, 'initiateMultipartUpload', timespan),
+                    timestamp, count],
+            ];
+            return this.ds.batch(cmds, callback);
+        });
     }
 
     /**
@@ -392,14 +409,15 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricCompleteMultipartUpload',
             bucket, timestamp,
         });
         return this.ds.batch([
-            ['incr', genBucketKey(bucket, 'numberOfObjectsCounter')],
-            ['incr', genBucketKey(bucket, 'completeMultipartUploadCounter')],
+            ['incr', genBucketCounter(bucket, 'numberOfObjectsCounter')],
+            ['incr',
+                genBucketCounter(bucket, 'completeMultipartUploadCounter')],
         ], (err, results) => {
             // number of objects counter
             if (err) {
@@ -425,9 +443,9 @@ export default class UtapiClient {
             } else {
                 cmds.push(
                     ['zremrangebyscore',
-                        genBucketKey(bucket, 'numberOfObjects'), timestamp,
-                        timestamp],
-                    ['zadd', genBucketKey(bucket, 'numberOfObjects'),
+                        genBucketStateKey(bucket, 'numberOfObjects'),
+                        timestamp, timestamp],
+                    ['zadd', genBucketStateKey(bucket, 'numberOfObjects'),
                         timestamp, actionCounter]);
             }
 
@@ -443,10 +461,12 @@ export default class UtapiClient {
             } else {
                 cmds.push(
                     ['zremrangebyscore',
-                        genBucketKey(bucket, 'completeMultipartUpload'),
+                        genBucketKey(bucket, 'completeMultipartUpload',
+                            timespan),
                         timestamp, timestamp],
                     ['zadd',
-                        genBucketKey(bucket, 'completeMultipartUpload'),
+                        genBucketKey(bucket, 'completeMultipartUpload',
+                            timespan),
                         timestamp, actionCounter]);
             }
             return this.ds.batch(cmds, callback);
@@ -466,13 +486,13 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricListBucketMultipartUploads',
             bucket, timestamp,
         });
         return this.ds.incr(
-            genBucketKey(bucket, 'listBucketMultipartUploadsCounter'),
+            genBucketCounter(bucket, 'listBucketMultipartUploadsCounter'),
             (err, count) => {
                 if (err) {
                     log.error('error incrementing counter', {
@@ -484,9 +504,11 @@ export default class UtapiClient {
                 }
                 const cmds = [
                     ['zremrangebyscore',
-                        genBucketKey(bucket, 'listBucketMultipartUploads'),
+                        genBucketKey(bucket, 'listBucketMultipartUploads',
+                            timespan),
                         timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'listBucketMultipartUploads'),
+                    ['zadd', genBucketKey(bucket, 'listBucketMultipartUploads',
+                        timespan),
                         timestamp, count],
                 ];
                 return this.ds.batch(cmds, callback);
@@ -506,13 +528,13 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricListMultipartUploadParts',
             bucket, timestamp,
         });
         return this.ds.incr(
-            genBucketKey(bucket, 'listMultipartUploadPartsCounter'),
+            genBucketCounter(bucket, 'listMultipartUploadPartsCounter'),
             (err, count) => {
                 if (err) {
                     log.error('error incrementing counter', {
@@ -524,9 +546,11 @@ export default class UtapiClient {
                 }
                 const cmds = [
                     ['zremrangebyscore',
-                        genBucketKey(bucket, 'listMultipartUploadParts'),
+                        genBucketKey(bucket, 'listMultipartUploadParts',
+                            timespan),
                         timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'listMultipartUploadParts'),
+                    ['zadd', genBucketKey(bucket, 'listMultipartUploadParts',
+                        timespan),
                         timestamp, count],
                 ];
                 return this.ds.batch(cmds, callback);
@@ -546,30 +570,29 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricAbortMultipartUpload',
             bucket, timestamp,
         });
-        return this.ds.incr(
-            genBucketKey(bucket, 'abortMultipartUploadCounter'),
-            (err, count) => {
-                if (err) {
-                    log.error('error incrementing counter', {
-                        method: 'UtapiClient.pushMetricAbortMultipartUpload',
-                        error: err,
-                    });
-                    return callback(err);
-                }
-                const cmds = [
-                    ['zremrangebyscore',
-                        genBucketKey(bucket, 'abortMultipartUpload'), timestamp,
-                        timestamp],
-                    ['zadd', genBucketKey(bucket, 'abortMultipartUpload'),
-                        timestamp, count],
-                ];
-                return this.ds.batch(cmds, callback);
-            });
+        const key = genBucketCounter(bucket, 'abortMultipartUploadCounter');
+        return this.ds.incr(key, (err, count) => {
+            if (err) {
+                log.error('error incrementing counter', {
+                    method: 'UtapiClient.pushMetricAbortMultipartUpload',
+                    error: err,
+                });
+                return callback(err);
+            }
+            const cmds = [
+                ['zremrangebyscore',
+                    genBucketKey(bucket, 'abortMultipartUpload', timespan),
+                    timestamp, timestamp],
+                ['zadd', genBucketKey(bucket, 'abortMultipartUpload', timespan),
+                    timestamp, count],
+            ];
+            return this.ds.batch(cmds, callback);
+        });
     }
 
     /**
@@ -586,16 +609,16 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricDeleteObject',
             bucket, timestamp,
         });
         return this.ds.batch([
-            ['decrby', genBucketKey(bucket, 'storageUtilizedCounter'),
+            ['decrby', genBucketCounter(bucket, 'storageUtilizedCounter'),
                 objectSize],
-            ['incr', genBucketKey(bucket, 'deleteObjectCounter')],
-            ['decr', genBucketKey(bucket, 'numberOfObjectsCounter')],
+            ['incr', genBucketCounter(bucket, 'deleteObjectCounter')],
+            ['decr', genBucketCounter(bucket, 'numberOfObjectsCounter')],
         ], (err, results) => {
             if (err || results[0][0]) {
                 log.error('error incrementing counter', {
@@ -620,9 +643,10 @@ export default class UtapiClient {
             } else {
                 cmds.push(
                     ['zremrangebyscore',
-                        genBucketKey(bucket, 'storageUtilized'), timestamp,
-                        timestamp],
-                    ['zadd', genBucketKey(bucket, 'storageUtilized'),
+                        genBucketStateKey(bucket, 'storageUtilized', timespan),
+                        timestamp, timestamp],
+                    ['zadd',
+                        genBucketStateKey(bucket, 'storageUtilized', timespan),
                         timestamp, tempCounter]);
             }
 
@@ -637,9 +661,10 @@ export default class UtapiClient {
                 });
             } else {
                 cmds.push(
-                    ['zremrangebyscore', genBucketKey(bucket, 'deleteObject'),
+                    ['zremrangebyscore',
+                        genBucketKey(bucket, 'deleteObject', timespan),
                         timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'deleteObject'),
+                    ['zadd', genBucketKey(bucket, 'deleteObject', timespan),
                         timestamp, actionCounter]);
             }
 
@@ -656,10 +681,10 @@ export default class UtapiClient {
             } else {
                 cmds.push(
                     ['zremrangebyscore',
-                        genBucketKey(bucket, 'numberOfObjects'), timestamp,
+                        genBucketStateKey(bucket, 'numberOfObjects'), timestamp,
                         timestamp],
-                    ['zadd', genBucketKey(bucket, 'numberOfObjects'),
-                 timestamp, tempCounter]);
+                    ['zadd', genBucketStateKey(bucket, 'numberOfObjects'),
+                        timestamp, tempCounter]);
             }
             return this.ds.batch(cmds, callback);
         });
@@ -679,14 +704,14 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricGetObject', bucket, timestamp });
         // update counters
         return this.ds.batch([
-            ['incrby', genBucketKey(bucket, 'outgoingBytesCounter'),
+            ['incrby', genBucketCounter(bucket, 'outgoingBytesCounter'),
             objectSize],
-            ['incr', genBucketKey(bucket, 'getObjectCounter')],
+            ['incr', genBucketCounter(bucket, 'outgoingBytesCounter')],
         ], (err, results) => {
             if (err) {
                 log.error('error pushing metric', {
@@ -707,10 +732,11 @@ export default class UtapiClient {
                 });
             } else {
                 cmds.push(
-                    ['zremrangebyscore', genBucketKey(bucket, 'outgoingBytes'),
+                    ['zremrangebyscore',
+                        genBucketStateKey(bucket, 'outgoingBytes'),
                         timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'outgoingBytes'), timestamp,
-                        actionCounter]);
+                    ['zadd', genBucketStateKey(bucket, 'outgoingBytes'),
+                        timestamp, actionCounter]);
             }
 
             // get object counter
@@ -724,10 +750,11 @@ export default class UtapiClient {
                 });
             } else {
                 cmds.push(
-                    ['zremrangebyscore', genBucketKey(bucket, 'getObject'),
+                    ['zremrangebyscore',
+                        genBucketKey(bucket, 'getObject', timespan),
                         timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'getObject'), timestamp,
-                        actionCounter]);
+                    ['zadd', genBucketKey(bucket, 'getObject', timespan),
+                        timestamp, actionCounter]);
             }
             return this.ds.batch(cmds, callback);
         });
@@ -746,28 +773,29 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricGetObjectAcl',
             bucket, timestamp,
         });
-        return this.ds.incr(genBucketKey(bucket, 'getObjectAclCounter'),
-            (err, count) => {
-                if (err) {
-                    log.error('error incrementing counter', {
-                        method: 'UtapiClient.pushMetricGetObjectAcl',
-                        error: err,
-                    });
-                    return callback(err);
-                }
-                const cmds = [
-                    ['zremrangebyscore', genBucketKey(bucket, 'getObjectAcl'),
-                        timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'getObjectAcl'), timestamp,
-                        count],
-                ];
-                return this.ds.batch(cmds, callback);
-            });
+        const key = genBucketCounter(bucket, 'getObjectAclCounter');
+        return this.ds.incr(key, (err, count) => {
+            if (err) {
+                log.error('error incrementing counter', {
+                    method: 'UtapiClient.pushMetricGetObjectAcl',
+                    error: err,
+                });
+                return callback(err);
+            }
+            const cmds = [
+                ['zremrangebyscore',
+                    genBucketKey(bucket, 'getObjectAcl', timespan), timestamp,
+                    timestamp],
+                ['zadd', genBucketKey(bucket, 'getObjectAcl', timespan),
+                    timestamp, count],
+            ];
+            return this.ds.batch(cmds, callback);
+        });
     }
 
 
@@ -787,15 +815,15 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
         let numberOfObjectsCounter;
         // if previous object size is null then it's a new object in a bucket
         // or else it's an old object being overwritten
         if (prevObjectSize === null) {
-            numberOfObjectsCounter = ['incr', genBucketKey(bucket,
+            numberOfObjectsCounter = ['incr', genBucketCounter(bucket,
                 'numberOfObjectsCounter')];
         } else {
-            numberOfObjectsCounter = ['get', genBucketKey(bucket,
+            numberOfObjectsCounter = ['get', genBucketCounter(bucket,
                 'numberOfObjectsCounter')];
         }
         let oldObjSize = parseInt(prevObjectSize, 10);
@@ -807,12 +835,12 @@ export default class UtapiClient {
             { method: 'UtapiClient.pushMetricPutObject', bucket, timestamp });
         // update counters
         return this.ds.batch([
-            ['incrby', genBucketKey(bucket, 'storageUtilizedCounter'),
+            ['incrby', genBucketCounter(bucket, 'storageUtilizedCounter'),
                 storageUtilizedDelta],
-            ['incrby', genBucketKey(bucket, 'incomingBytesCounter'),
+            ['incrby', genBucketCounter(bucket, 'incomingBytesCounter'),
                 objectSize],
             numberOfObjectsCounter,
-            ['incr', genBucketKey(bucket, 'putObjectCounter')],
+            ['incr', genBucketCounter(bucket, 'putObjectCounter')],
         ], (err, results) => {
             if (err) {
                 log.error('error pushing metric', {
@@ -836,10 +864,11 @@ export default class UtapiClient {
             } else {
                 cmds.push(
                     ['zremrangebyscore',
-                        genBucketKey(bucket, 'storageUtilized'), timestamp,
-                        timestamp],
-                    ['zadd', genBucketKey(bucket, 'storageUtilized'), timestamp,
-                    actionCounter]);
+                        genBucketStateKey(bucket, 'storageUtilized', timespan),
+                        timestamp, timestamp],
+                    ['zadd',
+                        genBucketStateKey(bucket, 'storageUtilized', timespan),
+                        timestamp, actionCounter]);
             }
 
             // incoming bytes counter
@@ -853,10 +882,11 @@ export default class UtapiClient {
                 });
             } else {
                 cmds.push(
-                    ['zremrangebyscore', genBucketKey(bucket, 'incomingBytes'),
+                    ['zremrangebyscore',
+                        genBucketStateKey(bucket, 'incomingBytes'),
                         timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'incomingBytes'), timestamp,
-                        actionCounter]);
+                    ['zadd', genBucketStateKey(bucket, 'incomingBytes'),
+                        timestamp, actionCounter]);
             }
 
             // number of objects counter
@@ -871,10 +901,10 @@ export default class UtapiClient {
             } else {
                 cmds.push(
                     ['zremrangebyscore',
-                        genBucketKey(bucket, 'numberOfObjects'), timestamp,
-                        timestamp],
-                    ['zadd', genBucketKey(bucket, 'numberOfObjects'), timestamp,
-                    actionCounter]);
+                        genBucketStateKey(bucket, 'numberOfObjects'),
+                        timestamp, timestamp],
+                    ['zadd', genBucketStateKey(bucket, 'numberOfObjects'),
+                        timestamp, actionCounter]);
             }
 
             // putObject counter
@@ -888,10 +918,11 @@ export default class UtapiClient {
                 });
             } else {
                 cmds.push(
-                    ['zremrangebyscore', genBucketKey(bucket, 'putObject'),
+                    ['zremrangebyscore',
+                        genBucketKey(bucket, 'putObject', timespan),
                         timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'putObject'), timestamp,
-                    actionCounter]);
+                    ['zadd', genBucketKey(bucket, 'putObject', timespan),
+                        timestamp, actionCounter]);
             }
             return this.ds.batch(cmds, callback);
         });
@@ -910,12 +941,12 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricPutObjectAcl',
             bucket, timestamp,
         });
-        return this.ds.incr(genBucketKey(bucket, 'putObjectAclCounter'),
+        return this.ds.incr(genBucketCounter(bucket, 'putObjectAclCounter'),
             (err, count) => {
                 if (err) {
                     log.error('error incrementing counter', {
@@ -925,10 +956,11 @@ export default class UtapiClient {
                     return callback(err);
                 }
                 const cmds = [
-                    ['zremrangebyscore', genBucketKey(bucket, 'putObjectAcl'),
+                    ['zremrangebyscore',
+                        genBucketKey(bucket, 'putObjectAcl', timespan),
                         timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'putObjectAcl'), timestamp,
-                        count],
+                    ['zadd', genBucketKey(bucket, 'putObjectAcl', timespan),
+                        timestamp, count],
                 ];
                 return this.ds.batch(cmds, callback);
             });
@@ -947,12 +979,12 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricHeadBucket',
             bucket, timestamp,
         });
-        return this.ds.incr(genBucketKey(bucket, 'headBucketCounter'),
+        return this.ds.incr(genBucketCounter(bucket, 'headBucketCounter'),
             (err, count) => {
                 if (err) {
                     log.error('error incrementing counter', {
@@ -962,10 +994,11 @@ export default class UtapiClient {
                     return callback(err);
                 }
                 const cmds = [
-                    ['zremrangebyscore', genBucketKey(bucket, 'headBucket'),
-                        timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'headBucket'), timestamp,
-                        count],
+                    ['zremrangebyscore',
+                        genBucketKey(bucket, 'headBucket', timespan), timestamp,
+                        timestamp],
+                    ['zadd', genBucketKey(bucket, 'headBucket', timespan),
+                        timestamp, count],
                 ];
                 return this.ds.batch(cmds, callback);
             });
@@ -984,12 +1017,12 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricHeadObject',
             bucket, timestamp,
         });
-        return this.ds.incr(genBucketKey(bucket, 'headObjectCounter'),
+        return this.ds.incr(genBucketCounter(bucket, 'headObjectCounter'),
             (err, count) => {
                 if (err) {
                     log.error('error incrementing counter', {
@@ -999,10 +1032,11 @@ export default class UtapiClient {
                     return callback(err);
                 }
                 const cmds = [
-                    ['zremrangebyscore', genBucketKey(bucket, 'headObject'),
+                    ['zremrangebyscore',
+                        genBucketKey(bucket, 'headObject', timespan),
                         timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'headObject'), timestamp,
-                        count],
+                    ['zadd', genBucketKey(bucket, 'headObject', timespan),
+                        timestamp, count],
                 ];
                 return this.ds.batch(cmds, callback);
             });

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,106 +1,100 @@
 // bucket schema
+const bucketStateKeys = {
+    storageUtilized: b => `s3:buckets:${b}:storageUtilized`,
+    numberOfObjects: b => `s3:buckets:${b}:numberOfObjects`,
+    incomingBytes: b => `s3:buckets:${b}:incomingBytes`,
+    outgoingBytes: b => `s3:buckets:${b}:outgoingBytes`,
+};
+
+const bucketCounters = {
+    storageUtilizedCounter: b => `s3:buckets:${b}:storageUtilized:counter`,
+    numberOfObjectsCounter: b => `s3:buckets:${b}:numberOfObjects:counter`,
+    incomingBytesCounter: b => `s3:buckets:${b}:incomingBytes:counter`,
+    outgoingBytesCounter: b => `s3:buckets:${b}:outgoingBytes:counter`,
+    createBucketCounter: b => `s3:buckets:${b}:CreateBucket:counter`,
+    deleteBucketCounter: b => `s3:buckets:${b}:DeleteBucket:counter`,
+    listBucketCounter: b => `s3:buckets:${b}:ListBucket:counter`,
+    getBucketAclCounter: b => `s3:buckets:${b}:GetBucketAcl:counter`,
+    putBucketAclCounter: b => `s3:buckets:${b}:PutBucketAcl:counter`,
+    listBucketMultipartUploadsCounter: b =>
+        `s3:buckets:${b}:ListBucketMultipartUploads:counter`,
+    listMultipartUploadPartsCounter: b =>
+        `s3:buckets:${b}:ListMultipartUploadParts:counter`,
+    initiateMultipartUploadCounter: b =>
+        `s3:buckets:${b}:InitiateMultipartUpload:counter`,
+    completeMultipartUploadCounter: b =>
+        `s3:buckets:${b}:CompleteMultipartUpload:counter`,
+    abortMultipartUploadCounter: b =>
+        `s3:buckets:${b}:AbortMultipartUpload:counter`,
+    deleteObjectCounter: b => `s3:buckets:${b}:DeleteObject:counter`,
+    uploadPartCounter: b => `s3:buckets:${b}:UploadPart:counter`,
+    getObjectCounter: b => `s3:buckets:${b}:GetObject:counter`,
+    getObjectAclCounter: b => `s3:buckets:${b}:GetObjectAcl:counter`,
+    putObjectCounter: b => `s3:buckets:${b}:PutObject:counter`,
+    putObjectAclCounter: b => `s3:buckets:${b}:PutObjectAcl:counter`,
+    headBucketCounter: b => `s3:buckets:${b}:HeadBucket:counter`,
+    headObjectCounter: b => `s3:buckets:${b}:HeadObject:counter`,
+    listAllMyBucketsCounter: b =>
+        `s3:buckets:${b}:ListAllMyBuckets:counter`,
+};
+
 const bucketKeys = {
-    storageUtilized: bucket => `s3:buckets:${bucket}:storageUtilized`,
-    incomingBytes: bucket => `s3:buckets:${bucket}:incomingBytes`,
-    outgoingBytes: bucket => `s3:buckets:${bucket}:outgoingBytes`,
-    numberOfObjects: bucket => `s3:buckets:${bucket}:numberOfObjects`,
-    createBucket: bucket => `s3:buckets:${bucket}:CreateBucket`,
-    deleteBucket: bucket => `s3:buckets:${bucket}:DeleteBucket`,
-    listBucket: bucket => `s3:buckets:${bucket}:ListBucket`,
-    getBucketAcl: bucket => `s3:buckets:${bucket}:GetBucketAcl`,
-    putBucketAcl: bucket => `s3:buckets:${bucket}:PutBucketAcl`,
-    listBucketMultipartUploads: bucket =>
-        `s3:buckets:${bucket}:ListBucketMultipartUploads`,
-    listMultipartUploadParts: bucket =>
-        `s3:buckets:${bucket}:ListMultipartUploadParts`,
-    initiateMultipartUpload: bucket =>
-        `s3:buckets:${bucket}:InitiateMultipartUpload`,
-    completeMultipartUpload: bucket =>
-        `s3:buckets:${bucket}:CompleteMultipartUpload`,
-    abortMultipartUpload: bucket =>
-        `s3:buckets:${bucket}:AbortMultipartUpload`,
-    deleteObject: bucket => `s3:buckets:${bucket}:DeleteObject`,
-    uploadPart: bucket => `s3:buckets:${bucket}:UploadPart`,
-    getObject: bucket => `s3:buckets:${bucket}:GetObject`,
-    getObjectAcl: bucket => `s3:buckets:${bucket}:GetObjectAcl`,
-    putObject: bucket => `s3:buckets:${bucket}:PutObject`,
-    putObjectAcl: bucket => `s3:buckets:${bucket}:PutObjectAcl`,
-    headBucket: bucket => `s3:buckets:${bucket}:HeadBucket`,
-    headObject: bucket => `s3:buckets:${bucket}:HeadObject`,
-    listAllMyBuckets: bucket => `s3:buckets:${bucket}:ListAllMyBuckets`,
-    storageUtilizedCounter: bucket =>
-        `s3:buckets:${bucket}:storageUtilized:counter`,
-    incomingBytesCounter: bucket =>
-        `s3:buckets:${bucket}:incomingBytes:counter`,
-    outgoingBytesCounter: bucket =>
-        `s3:buckets:${bucket}:outgoingBytes:counter`,
-    numberOfObjectsCounter: bucket =>
-        `s3:buckets:${bucket}:numberOfObjects:counter`,
-    createBucketCounter: bucket => `s3:buckets:${bucket}:CreateBucket:counter`,
-    deleteBucketCounter: bucket => `s3:buckets:${bucket}:DeleteBucket:counter`,
-    listBucketCounter: bucket => `s3:buckets:${bucket}:ListBucket:counter`,
-    getBucketAclCounter: bucket => `s3:buckets:${bucket}:GetBucketAcl:counter`,
-    putBucketAclCounter: bucket => `s3:buckets:${bucket}:PutBucketAcl:counter`,
-    listBucketMultipartUploadsCounter: bucket =>
-        `s3:buckets:${bucket}:ListBucketMultipartUploads:counter`,
-    listMultipartUploadPartsCounter: bucket =>
-        `s3:buckets:${bucket}:ListMultipartUploadParts:counter`,
-    initiateMultipartUploadCounter: bucket =>
-        `s3:buckets:${bucket}:InitiateMultipartUpload:counter`,
-    completeMultipartUploadCounter: bucket =>
-        `s3:buckets:${bucket}:CompleteMultipartUpload:counter`,
-    abortMultipartUploadCounter: bucket =>
-        `s3:buckets:${bucket}:AbortMultipartUpload:counter`,
-    deleteObjectCounter: bucket => `s3:buckets:${bucket}:DeleteObject:counter`,
-    uploadPartCounter: bucket => `s3:buckets:${bucket}:UploadPart:counter`,
-    getObjectCounter: bucket => `s3:buckets:${bucket}:GetObject:counter`,
-    getObjectAclCounter: bucket => `s3:buckets:${bucket}:GetObjectAcl:counter`,
-    putObjectCounter: bucket => `s3:buckets:${bucket}:PutObject:counter`,
-    putObjectAclCounter: bucket => `s3:buckets:${bucket}:PutObjectAcl:counter`,
-    headBucketCounter: bucket => `s3:buckets:${bucket}:HeadBucket:counter`,
-    headObjectCounter: bucket => `s3:buckets:${bucket}:HeadObject:counter`,
-    listAllMyBucketsCounter: bucket =>
-        `s3:buckets:${bucket}:ListAllMyBuckets:counter`,
+    createBucket: (b, t) => `s3:buckets:${t}:${b}:CreateBucket`,
+    deleteBucket: (b, t) => `s3:buckets:${t}:${b}:DeleteBucket`,
+    listBucket: (b, t) => `s3:buckets:${t}:${b}:ListBucket`,
+    getBucketAcl: (b, t) => `s3:buckets:${t}:${b}:GetBucketAcl`,
+    putBucketAcl: (b, t) => `s3:buckets:${t}:${b}:PutBucketAcl`,
+    listBucketMultipartUploads: (b, t) =>
+        `s3:buckets:${t}:${b}:ListBucketMultipartUploads`,
+    listMultipartUploadParts: (b, t) =>
+        `s3:buckets:${t}:${b}:ListMultipartUploadParts`,
+    initiateMultipartUpload: (b, t) =>
+        `s3:buckets:${t}:${b}:InitiateMultipartUpload`,
+    completeMultipartUpload: (b, t) =>
+        `s3:buckets:${t}:${b}:CompleteMultipartUpload`,
+    abortMultipartUpload: (b, t) =>
+        `s3:buckets:${t}:${b}:AbortMultipartUpload`,
+    deleteObject: (b, t) => `s3:buckets:${t}:${b}:DeleteObject`,
+    uploadPart: (b, t) => `s3:buckets:${t}:${b}:UploadPart`,
+    getObject: (b, t) => `s3:buckets:${t}:${b}:GetObject`,
+    getObjectAcl: (b, t) => `s3:buckets:${t}:${b}:GetObjectAcl`,
+    putObject: (b, t) => `s3:buckets:${t}:${b}:PutObject`,
+    putObjectAcl: (b, t) => `s3:buckets:${t}:${b}:PutObjectAcl`,
+    headBucket: (b, t) => `s3:buckets:${t}:${b}:HeadBucket`,
+    headObject: (b, t) => `s3:buckets:${t}:${b}:HeadObject`,
+    listAllMyBuckets: (b, t) => `s3:buckets:${t}:${b}:ListAllMyBuckets`,
 };
 
 /**
 * Returns the metric key in schema for the bucket
 * @param {string} bucket - bucket name
 * @param {string} metric - metric name
+* @param {number} timespan - unix timestamp normalized to the date
 * @return {string} - schema key
 */
-export function genBucketKey(bucket, metric) {
-    return bucketKeys[metric](bucket);
+export function genBucketKey(bucket, metric, timespan) {
+    return bucketKeys[metric](bucket, timespan);
 }
 
 /**
-* Returns a list of the global counters for a bucket
+* Returns a list of the counters for a bucket
 * @param {string} bucket - bucket name
-* @return {string} - schema key
+* @return {string[]} - array of keys for counters
 */
-export function getBucketGlobalCounters(bucket) {
-    const keys = [];
-    Object.keys(bucketKeys).forEach(item => {
-        if (item.indexOf('Counter') !== -1) {
-            keys.push(bucketKeys[item](bucket));
-        }
-    });
-    return keys;
+export function getBucketCounters(bucket) {
+    return Object.keys(bucketCounters).map(
+        item => bucketCounters[item](bucket));
 }
 
 /**
 * Returns a list of all keys for a bucket
 * @param {string} bucket - bucket name
-* @return {string} - schema key
+* @param {number} timespan - normalized timespan reduced to the day
+* @return {string[]} - list of keys
 */
-export function getBucketKeys(bucket) {
+export function getBucketKeys(bucket, timespan) {
     return Object.keys(bucketKeys)
-        .filter(item => item.indexOf('Counter') === -1
-            && item.indexOf('storageUtilized') === -1
-            && item.indexOf('numberOfObjects') === -1
-            && item.indexOf('incomingBytes') === -1
-            && item.indexOf('outgoingBytes') === -1)
-        .map(item => bucketKeys[item](bucket));
+        .map(item => bucketKeys[item](bucket, timespan));
 }
 
 /**
@@ -110,5 +104,30 @@ export function getBucketKeys(bucket) {
 * @return {string} metric - S3 metric
 */
 export function getMetricFromKey(key, bucket) {
-    return key.replace(`s3:buckets:${bucket}:`, '');
+    // s3:buckets:1473451689898:demo:putObject
+    return key.slice(25).replace(`${bucket}:`, '');
+}
+
+/**
+* Returns the keys representing state of the bucket
+* @param {string} bucket - bucket name
+* @return {string[]} - list of keys
+*/
+export function getBucketStateKeys(bucket) {
+    return Object.keys(bucketStateKeys)
+        .map(item => bucketStateKeys[item](bucket));
+}
+
+/**
+* Returns the state metric key in schema for the bucket
+* @param {string} bucket - bucket name
+* @param {string} metric - metric name
+* @return {string} - schema key
+*/
+export function genBucketStateKey(bucket, metric) {
+    return bucketStateKeys[metric](bucket);
+}
+
+export function genBucketCounter(bucket, metric) {
+    return bucketCounters[metric](bucket);
 }

--- a/tests/functional/testUtapiClient.js
+++ b/tests/functional/testUtapiClient.js
@@ -3,7 +3,7 @@ import { mapSeries, series } from 'async';
 import UtapiClient from '../../lib/UtapiClient';
 import MemoryBackend from '../../lib/backend/Memory';
 import Datastore from '../../lib/Datastore';
-import { getBucketGlobalCounters, getMetricFromKey } from '../../lib/schema';
+import { getBucketCounters, getMetricFromKey } from '../../lib/schema';
 const testBucket = 'foo';
 const memBackend = new MemoryBackend();
 const datastore = new Datastore();
@@ -13,8 +13,8 @@ datastore.setClient(memBackend);
 utapiClient.setDataStore(datastore);
 
 function _assertCounters(bucket, cb) {
-    const gCounters = getBucketGlobalCounters(testBucket);
-    return mapSeries(gCounters, (item, next) =>
+    const counters = getBucketCounters(testBucket);
+    return mapSeries(counters, (item, next) =>
         memBackend.get(item, (err, res) => {
             if (err) {
                 return next(err);
@@ -33,13 +33,13 @@ function _assertCounters(bucket, cb) {
 describe('Counters', () => {
     afterEach(() => memBackend.flushDb());
 
-    it('should set global counters (other than create bucket counter) to 0 on' +
+    it('should set counters (other than create bucket counter) to 0 on' +
         ' bucket creation', done => {
         utapiClient.pushMetricCreateBucket(reqUid, testBucket,
             () => _assertCounters(testBucket, done));
     });
 
-    it('should reset global counters on bucket re-creation', done => {
+    it('should reset counters on bucket re-creation', done => {
         series([
             next => utapiClient.pushMetricCreateBucket(reqUid, testBucket,
                 next),

--- a/utils/getTimespan.js
+++ b/utils/getTimespan.js
@@ -1,0 +1,9 @@
+/**
+* Takes a timestamp and normalizes it to the day by removing hours, minutes,
+* seconds and milliseconds
+* @param {number} timestamp - unix timestamp
+* @return {number} timespan - timestamp normalized to the day
+*/
+export default function getTimespan(timestamp) {
+    return new Date(timestamp).setHours(0, 0, 0, 0);
+}

--- a/validators/Validator.js
+++ b/validators/Validator.js
@@ -19,7 +19,12 @@ const keyMap = new Map([
  */
 const keyError = new Map([
     ['buckets', errors.InvalidParameterValue],
-    ['timeRange', errors.InvalidParameterValue],
+    ['timeRange', errors.InvalidParameterValue.customizeDescription(
+        'Timestamps must be one of the following intervals for any day/hour' +
+            ' (mm:ss:SS) - start must be one of [00:00:000, 15:00:000, ' +
+            '30:00:000, 45:00:000], end must be one of [14:59:999,' +
+            ' 29:59:999, 44:59:999, 59:59:999].'
+    )],
 ]);
 
 /**

--- a/validators/validateTimeRange.js
+++ b/validators/validateTimeRange.js
@@ -4,7 +4,40 @@
 * @return {boolean} - validation result
 */
 export default function validateTimeRange(timeRange) {
-    return Array.isArray(timeRange) && timeRange.length > 0
-        && timeRange.length < 3
-        && timeRange.every(item => typeof item === 'number');
+    if (Array.isArray(timeRange) && timeRange.length > 0 && timeRange.length < 3
+        && timeRange.every(item => typeof item === 'number')) {
+        // check for start time
+        const t0 = new Date(timeRange[0]);
+        const min0 = t0.getMinutes();
+        const sec0 = t0.getSeconds();
+        const ms0 = t0.getMilliseconds();
+        if (min0 !== 0 && min0 !== 15 && min0 !== 30 && min0 !== 45) {
+            return false;
+        }
+        if (sec0 !== 0) {
+            return false;
+        }
+        if (ms0 !== 0) {
+            return false;
+        }
+
+        // check for end time
+        if (timeRange[1] !== undefined) {
+            const t1 = new Date(timeRange[1]);
+            const min1 = t1.getMinutes();
+            const sec1 = t1.getSeconds();
+            const ms1 = t1.getMilliseconds();
+            if ((min1 !== 14 && min1 !== 29 && min1 !== 44 && min1 !== 59)) {
+                return false;
+            }
+            if (sec1 !== 59) {
+                return false;
+            }
+            if (ms1 !== 999) {
+                return false;
+            }
+        }
+        return true;
+    }
+    return false;
 }


### PR DESCRIPTION
This commit adds sharding to the sorted sets that are used to hold the entries per timestamp.

- The sharding is done so that milliseconds, seconds, minutes and hours are
  set to 0 in the timestamp which does not change for a day, and is appended to
  the sorted set key. This way a new sorted set is used for a bucket-metric combo
  to keep their size small.
- Small sorted sets make use of ziplist encoding in Redis which dramatically decreases
   the serialized length of the sorted set.

Things not sharded:
  - **counters**: counters need not be sharded as they are strings only
  - **absolute sets**: storage utilized, number of objects, incoming bytes,
  outgoing bytes. These sets use nearest neighbor calculations, sharding
  these would make calculating the metrics a very expensive problem.
