### PR TITLE
fix: operations counters

### DIFF
--- a/lib/Buckets.js
+++ b/lib/Buckets.js
@@ -1,7 +1,6 @@
 import async from 'async';
 import { errors } from 'arsenal';
 import { getMetricFromKey, getBucketKeys, genBucketStateKey } from './schema';
-import getTimespan from '../utils/getTimespan';
 
 /**
 * Provides static methods to get bucket level metrics
@@ -35,19 +34,19 @@ export default class Buckets {
     }
 
     /**
-    * Returns a list of timestamps incremented by a day starting from start
-    * to end
+    * Returns a list of timestamps incremented by 15 min. from start timestamp
+    * to end timestamp
     * @param {number} start - start timestamp
     * @param {number} end - end timestamp
     * @return {number[]} range - array of timestamps
     */
-    static getTimespanRange(start, end) {
+    static getTimestampRange(start, end) {
         const res = [];
         let last = start;
-        while (last !== end) {
+        while (last < end) {
             res.push(last);
             const d = new Date(last);
-            last = d.setDate(d.getDate() + 1);
+            last = d.setMinutes(d.getMinutes() + 15);
         }
         res.push(end);
         return res;
@@ -85,13 +84,11 @@ export default class Buckets {
     */
     static getBucketMetrics(bucket, range, datastore, log, cb) {
         const start = range[0];
-        const startspan = getTimespan(start);
         const end = range[1] || Date.now();
-        const endspan = getTimespan(end);
+
+        // find nearest neighbors for absolutes
         const storageUtilizedKey = genBucketStateKey(bucket, 'storageUtilized');
         const numberOfObjectsKey = genBucketStateKey(bucket, 'numberOfObjects');
-        const incomingBytesKey = genBucketStateKey(bucket, 'incomingBytes');
-        const outgoingBytesKey = genBucketStateKey(bucket, 'outgoingBytes');
         const storageUtilizedStart = ['zrevrangebyscore', storageUtilizedKey,
             start, '-inf', 'LIMIT', '0', '1'];
         const storageUtilizedEnd = ['zrevrangebyscore', storageUtilizedKey, end,
@@ -100,22 +97,12 @@ export default class Buckets {
             start, '-inf', 'LIMIT', '0', '1'];
         const numberOfObjectsEnd = ['zrevrangebyscore', numberOfObjectsKey, end,
             '-inf', 'LIMIT', '0', '1'];
-        const incomingBytesStart = ['zrevrangebyscore', incomingBytesKey,
-            start, '-inf', 'LIMIT', '0', '1'];
-        const incomingBytesEnd = ['zrevrangebyscore', incomingBytesKey, end,
-            '-inf', 'LIMIT', '0', '1'];
-        const outgoingBytesStart = ['zrevrangebyscore', outgoingBytesKey, start,
-            '-inf', 'LIMIT', '0', '1'];
-        const outgoingBytesEnd = ['zrevrangebyscore', outgoingBytesKey, end,
-            '-inf', 'LIMIT', '0', '1'];
-        const timespanRange = Buckets.getTimespanRange(startspan, endspan);
-        const bucketKeys = [].concat.apply([],
-            timespanRange.map(i => getBucketKeys(bucket, i)));
-        const cmds = bucketKeys.map(item => ['zrangebyscore', item, start,
-            end]);
+        const timestampRange = Buckets.getTimestampRange(start, end);
+        const bucketKeys = [].concat.apply([], timestampRange.map(
+            i => getBucketKeys(bucket, i)));
+        const cmds = bucketKeys.map(item => ['get', item]);
         cmds.push(storageUtilizedStart, storageUtilizedEnd,
-            numberOfObjectsStart, numberOfObjectsEnd, incomingBytesStart,
-            incomingBytesEnd, outgoingBytesStart, outgoingBytesEnd);
+            numberOfObjectsStart, numberOfObjectsEnd);
 
         datastore.batch(cmds, (err, res) => {
             if (err) {
@@ -150,17 +137,14 @@ export default class Buckets {
                     's3:GetObject': 0,
                     's3:GetObjectAcl': 0,
                     's3:PutObjectAcl': 0,
-                    's3:ListAllMyBuckets': 0,
                     's3:HeadBucket': 0,
                     's3:HeadObject': 0,
                 },
             };
 
-            // last 8 are results of storageUtilized, numberOfObjects,
-            // incomingBytes and outgoingBytes
-            const absolutes = res.splice(-8);
-            const incomingBytes = [0, 0];
-            const outgoingBytes = [0, 0];
+            // last 4 are results of storageUtilized, numberOfObjects,
+            const absolutes = res.slice(-4);
+            const deltas = res.slice(0, res.length - 4);
             absolutes.forEach((item, index) => {
                 if (item[0]) {
                     // log error and continue
@@ -179,31 +163,18 @@ export default class Buckets {
                         bucketRes.numberOfObjects[0] = val;
                     } else if (index === 3) {
                         bucketRes.numberOfObjects[1] = val;
-                    } else if (index === 4) {
-                        incomingBytes[0] = val;
-                    } else if (index === 5) {
-                        incomingBytes[1] = val;
-                    } else if (index === 6) {
-                        outgoingBytes[0] = val;
-                    } else if (index === 7) {
-                        outgoingBytes[1] = val;
                     }
                 }
             });
-            // calculate the delta values for incoming and outgoing bytes
-            bucketRes.incomingBytes = Math.abs(
-                incomingBytes[1] - incomingBytes[0]);
-            bucketRes.outgoingBytes = Math.abs(
-                outgoingBytes[1] - outgoingBytes[0]);
 
             /**
             * Batch result is of the format
-            * [ [null, ['1', '2', '3']], [null, ['4', '5', '6']] ] where each
+            * [ [null, '1'], [null, '2'], [null, '3'] ] where each
             * item is the result of the each batch command
             * Foreach item in the resut, index 0 signifies the error and
             * index 1 contains the result
             */
-            res.forEach((item, index) => {
+            deltas.forEach((item, index) => {
                 const key = bucketKeys[index];
                 if (item[0]) {
                     // log error and continue
@@ -212,12 +183,15 @@ export default class Buckets {
                         method: 'Buckets.getBucketMetrics',
                         cmd: key,
                     });
-                } else if (Array.isArray(item[1])) {
-                    // convert strings to numbers for comparision
+                } else {
                     const m = getMetricFromKey(key, bucket);
-                    // count is enough as it represents the delta of the
-                    // metric between the two timestamps
-                    bucketRes.operations[`s3:${m}`] += item[1].length || 0;
+                    let count = parseInt(item[1], 10);
+                    count = Number.isNaN(count) ? 0 : count;
+                    if (m === 'incomingBytes' || m === 'outgoingBytes') {
+                        bucketRes[m] += count;
+                    } else {
+                        bucketRes.operations[`s3:${m}`] += count;
+                    }
                 }
             });
             return cb(null, bucketRes);

--- a/lib/UtapiClient.js
+++ b/lib/UtapiClient.js
@@ -2,6 +2,7 @@ import { Logger } from 'werelogs';
 import Datastore from './Datastore';
 import { genBucketKey, genBucketCounter, getBucketCounters, genBucketStateKey }
     from './schema';
+import { errors } from 'arsenal';
 import redisClient from '../utils/redisClient';
 
 export default class UtapiClient {
@@ -26,19 +27,14 @@ export default class UtapiClient {
     }
 
     /**
-    * Normalizes timestamp precision to a 15 minutes interval to
+    * Normalizes timestamp precision to the nearest 15 minutes to
     * reduce the number of entries in a sorted set
-    * @return {object} normalizedTime - normalized time
-    * @property {number} normalizedTime.timestamp - normalized to the
-    * nearest 15 minutes interval
-    * @property {number} normalizedTime.timespan - normalized to the date
+    * @return {number} timestamp - normalized to the nearest 15 minutes
     */
-    static getNormalizedTime() {
+    static getNormalizedTimestamp() {
         const d = new Date();
         const minutes = d.getMinutes();
-        const timestamp = d.setMinutes((minutes - minutes % 15), 0, 0);
-        const timespan = d.setHours(0, 0);
-        return { timestamp, timespan };
+        return d.setMinutes((minutes - minutes % 15), 0, 0);
     }
 
     /**
@@ -71,33 +67,23 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricCreateBucket',
             bucket, timestamp,
         });
-        const cmds = [];
-        // set counters to 0 except for create bucket counter (set to 1)
-        // indicating start of bucket timeline
-        getBucketCounters(bucket).forEach(item => {
-            if (item.indexOf('CreateBucket:counter') !== -1) {
-                cmds.push(['set', item, 1]);
-            } else {
-                cmds.push(['set', item, 0]);
-            }
-        });
+        // set storage utilized and number of objects  counters to 0,
+        // indicating the start of the bucket timeline
+        const cmds = getBucketCounters(bucket).map(item => ['set', item, 0]);
         cmds.push(
             // remove old timestamp entries
-            ['zremrangebyscore', genBucketKey(bucket, 'createBucket', timespan),
-                timestamp, timestamp],
             ['zremrangebyscore',
                 genBucketStateKey(bucket, 'storageUtilized'), timestamp,
                 timestamp],
             ['zremrangebyscore', genBucketStateKey(bucket, 'numberOfObjects'),
                 timestamp, timestamp],
             // add new timestamp entries
-            ['zadd', genBucketKey(bucket, 'createBucket', timespan), timestamp,
-                1],
+            ['set', genBucketKey(bucket, 'createBucket', timestamp), 1],
             ['zadd', genBucketStateKey(bucket, 'storageUtilized'), timestamp,
                 0],
             ['zadd', genBucketStateKey(bucket, 'numberOfObjects'), timestamp, 0]
@@ -108,7 +94,7 @@ export default class UtapiClient {
                     method: 'Buckets.pushMetricCreateBucket',
                     error: err,
                 });
-                return callback(err);
+                return callback(errors.InternalError);
             }
             return callback();
         });
@@ -127,31 +113,23 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricDeleteBucket',
             bucket, timestamp,
         });
-        const key = genBucketCounter(bucket, 'deleteBucketCounter');
-        return this.ds.set(key, 1, err => {
+        const key = genBucketKey(bucket, 'deleteBucket', timestamp);
+        return this.ds.incr(key, err => {
             if (err) {
                 log.error('error incrementing counter', {
                     method: 'Buckets.pushMetricDeleteBucket',
                     error: err,
                 });
-                return callback(err);
+                return callback(errors.InternalError);
             }
-            const cmds = [
-                ['zremrangebyscore',
-                    genBucketKey(bucket, 'deleteBucket', timespan), timestamp,
-                    timestamp],
-                ['zadd', genBucketKey(bucket, 'deleteBucket', timespan),
-                    timestamp, 1],
-            ];
-            return this.ds.batch(cmds, callback);
+            return callback();
         });
     }
-
 
     /**
     * Updates counter for ListBucket action on a Bucket resource.
@@ -166,29 +144,22 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricListBucket',
             bucket, timestamp,
         });
-        return this.ds.incr(genBucketCounter(bucket, 'listBucketCounter'),
-            (err, count) => {
-                if (err) {
-                    log.error('error incrementing counter', {
-                        method: 'Buckets.pushMetricListBucket',
-                        error: err,
-                    });
-                    return callback(err);
-                }
-                const cmds = [
-                    ['zremrangebyscore',
-                        genBucketKey(bucket, 'listBucket', timespan), timestamp,
-                        timestamp],
-                    ['zadd', genBucketKey(bucket, 'listBucket', timespan),
-                        timestamp, count],
-                ];
-                return this.ds.batch(cmds, callback);
-            });
+        const key = genBucketKey(bucket, 'listBucket', timestamp);
+        return this.ds.incr(key, err => {
+            if (err) {
+                log.error('error incrementing counter', {
+                    method: 'Buckets.pushMetricListBucket',
+                    error: err,
+                });
+                return callback(errors.InternalError);
+            }
+            return callback();
+        });
     }
 
     /**
@@ -204,27 +175,20 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', { method: 'UtapiClient.pushMetricGet' +
             'BucketAcl',
             bucket, timestamp });
-        const key = genBucketCounter(bucket, 'getBucketAclCounter');
-        return this.ds.incr(key, (err, count) => {
+        const key = genBucketKey(bucket, 'getBucketAcl', timestamp);
+        return this.ds.incr(key, err => {
             if (err) {
                 log.error('error incrementing counter', {
                     method: 'Buckets.pushMetricGetBucketAcl',
                     error: err,
                 });
-                return callback(err);
+                return callback(errors.InternalError);
             }
-            const cmds = [
-                ['zremrangebyscore',
-                    genBucketKey(bucket, 'getBucketAcl', timespan), timestamp,
-                    timestamp],
-                ['zadd', genBucketKey(bucket, 'getBucketAcl', timespan),
-                    timestamp, count],
-            ];
-            return this.ds.batch(cmds, callback);
+            return callback();
         });
     }
 
@@ -241,26 +205,19 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricPutBucketAcl', bucket, timestamp });
-        const key = genBucketCounter(bucket, 'putBucketAclCounter');
-        return this.ds.incr(key, (err, count) => {
+        const key = genBucketKey(bucket, 'putBucketAcl', timestamp);
+        return this.ds.incr(key, err => {
             if (err) {
                 log.error('error incrementing counter', {
                     method: 'Buckets.pushMetricPutBucketAcl',
                     error: err,
                 });
-                return callback(err);
+                return callback(errors.InternalError);
             }
-            const cmds = [
-                ['zremrangebyscore',
-                    genBucketKey(bucket, 'putBucketAcl', timespan),
-                    timestamp, timestamp],
-                ['zadd', genBucketKey(bucket, 'putBucketAcl', timespan),
-                    timestamp, count],
-            ];
-            return this.ds.batch(cmds, callback);
+            return callback();
         });
     }
 
@@ -278,82 +235,43 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricUploadPart', bucket, timestamp });
         // update counters
         return this.ds.batch([
             ['incrby', genBucketCounter(bucket, 'storageUtilizedCounter'),
                 objectSize],
-            ['incrby', genBucketCounter(bucket, 'incomingBytesCounter'),
+            ['incrby', genBucketKey(bucket, 'incomingBytes', timestamp),
                 objectSize],
-            ['incr', genBucketCounter(bucket, 'uploadPartCounter')],
+            ['incr', genBucketKey(bucket, 'uploadPart', timestamp)],
         ], (err, results) => {
             if (err) {
                 log.error('error pushing metric', {
                     method: 'UtapiClient.pushMetricUploadPart',
                     error: err,
                 });
-                return callback(err);
+                return callback(errors.InternalError);
             }
-            const cmds = [];
-            let actionErr;
-            let actionCounter;
             // storage utilized counter
-            actionErr = results[0][0];
-            actionCounter = results[0][1];
+            const actionErr = results[0][0];
+            const actionCounter = results[0][1];
             if (actionErr) {
                 log.error('error incrementing counter for push metric', {
                     method: 'UtapiClient.pushMetricUploadPart',
                     metric: 'storage utilized',
                     error: actionErr,
                 });
-            } else {
-                cmds.push(
-                    ['zremrangebyscore',
-                        genBucketStateKey(bucket, 'storageUtilized'),
-                        timestamp, timestamp],
-                    ['zadd',
-                        genBucketStateKey(bucket, 'storageUtilized'),
-                        timestamp, actionCounter]
-                );
+                return callback(errors.InternalError);
             }
 
-            // incoming bytes counter
-            actionErr = results[1][0];
-            actionCounter = results[1][1];
-            if (actionErr) {
-                log.error('error incrementing counter for push metric', {
-                    method: 'UtapiClient.pushMetricUploadPart',
-                    metric: 'incoming bytes',
-                    error: actionErr,
-                });
-            } else {
-                cmds.push(
-                    ['zremrangebyscore',
-                        genBucketStateKey(bucket, 'incomingBytes'),
-                        timestamp, timestamp],
-                    ['zadd', genBucketStateKey(bucket, 'incomingBytes'),
-                        timestamp, actionCounter]);
-            }
-            // uploadPart counter
-            actionErr = results[2][0];
-            actionCounter = results[2][1];
-            if (actionErr) {
-                log.error('error incrementing counter for push metric', {
-                    method: 'UtapiClient.pushMetricUploadPart',
-                    metric: 'uploadPart',
-                    error: actionErr,
-                });
-            } else {
-                cmds.push(
-                    ['zremrangebyscore',
-                        genBucketKey(bucket, 'uploadPart', timespan),
-                        timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'uploadPart', timespan),
-                        timestamp, actionCounter]);
-            }
-            return this.ds.batch(cmds, callback);
+            return this.ds.batch([
+                ['zremrangebyscore',
+                    genBucketStateKey(bucket, 'storageUtilized'),
+                    timestamp, timestamp],
+                ['zadd', genBucketStateKey(bucket, 'storageUtilized'),
+                    timestamp, actionCounter],
+            ], callback);
         });
     }
 
@@ -370,29 +288,21 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricInitiateMultipartUpload',
             bucket, timestamp,
         });
-        const key = genBucketCounter(bucket, 'initiateMultipartUploadCounter');
-        return this.ds.incr(key, (err, count) => {
+        const key = genBucketKey(bucket, 'initiateMultipartUpload', timestamp);
+        return this.ds.incr(key, err => {
             if (err) {
                 log.error('error incrementing counter', {
                     method: 'UtapiClient.pushMetricInitiateMultipartUpload',
                     error: err,
                 });
-                return callback(err);
+                return callback(errors.InternalError);
             }
-            const cmds = [
-                ['zremrangebyscore',
-                    genBucketKey(bucket, 'initiateMultipartUpload', timespan),
-                    timestamp, timestamp],
-                ['zadd',
-                    genBucketKey(bucket, 'initiateMultipartUpload', timespan),
-                    timestamp, count],
-            ];
-            return this.ds.batch(cmds, callback);
+            return callback();
         });
     }
 
@@ -409,67 +319,40 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricCompleteMultipartUpload',
             bucket, timestamp,
         });
         return this.ds.batch([
             ['incr', genBucketCounter(bucket, 'numberOfObjectsCounter')],
-            ['incr',
-                genBucketCounter(bucket, 'completeMultipartUploadCounter')],
+            ['incr', genBucketKey(bucket, 'completeMultipartUpload',
+                timestamp)],
         ], (err, results) => {
-            // number of objects counter
             if (err) {
                 log.error('error incrementing counter for push metric', {
-                    method: 'UtapiClient.pushMetricPutObject',
+                    method: 'UtapiClient.pushMetricCompleteMultipartUpload',
                     metric: 'number of objects',
                     error: err,
                 });
-                return callback(err);
+                return callback(errors.InternalError);
             }
-            const cmds = [];
-            let actionErr;
-            let actionCounter;
-            // storage utilized counter
-            actionErr = results[0][0];
-            actionCounter = results[0][1];
+            // number of objects counter
+            const actionErr = results[0][0];
+            const actionCounter = results[0][1];
             if (actionErr) {
                 log.error('error incrementing counter for push metric', {
                     method: 'UtapiClient.pushMetricCompleteMultipartUpload',
                     metric: 'number of objects',
                     error: actionErr,
                 });
-            } else {
-                cmds.push(
-                    ['zremrangebyscore',
-                        genBucketStateKey(bucket, 'numberOfObjects'),
-                        timestamp, timestamp],
-                    ['zadd', genBucketStateKey(bucket, 'numberOfObjects'),
-                        timestamp, actionCounter]);
+                return callback(errors.InternalError);
             }
-
-            // completeMultipartUpload counter
-            actionErr = results[1][0];
-            actionCounter = results[1][1];
-            if (actionErr) {
-                log.error('error incrementing counter for push metric', {
-                    method: 'UtapiClient.pushMetricCompleteMultipartUpload',
-                    metric: 'number of objects',
-                    error: actionErr,
-                });
-            } else {
-                cmds.push(
-                    ['zremrangebyscore',
-                        genBucketKey(bucket, 'completeMultipartUpload',
-                            timespan),
-                        timestamp, timestamp],
-                    ['zadd',
-                        genBucketKey(bucket, 'completeMultipartUpload',
-                            timespan),
-                        timestamp, actionCounter]);
-            }
-            return this.ds.batch(cmds, callback);
+            const key = genBucketStateKey(bucket, 'numberOfObjects');
+            return this.ds.batch([
+                ['zremrangebyscore', key, timestamp, timestamp],
+                ['zadd', key, timestamp, actionCounter],
+            ], callback);
         });
     }
 
@@ -486,33 +369,24 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricListBucketMultipartUploads',
             bucket, timestamp,
         });
-        return this.ds.incr(
-            genBucketCounter(bucket, 'listBucketMultipartUploadsCounter'),
-            (err, count) => {
-                if (err) {
-                    log.error('error incrementing counter', {
-                        method: 'UtapiClient.pushMetricListBucketMultipart' +
-                            'Uploads',
-                        error: err,
-                    });
-                    return callback(err);
-                }
-                const cmds = [
-                    ['zremrangebyscore',
-                        genBucketKey(bucket, 'listBucketMultipartUploads',
-                            timespan),
-                        timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'listBucketMultipartUploads',
-                        timespan),
-                        timestamp, count],
-                ];
-                return this.ds.batch(cmds, callback);
-            });
+        const key = genBucketKey(bucket, 'listBucketMultipartUploads',
+            timestamp);
+        return this.ds.incr(key, err => {
+            if (err) {
+                log.error('error incrementing counter', {
+                    method: 'UtapiClient.pushMetricListBucketMultipart' +
+                        'Uploads',
+                    error: err,
+                });
+                return callback(errors.InternalError);
+            }
+            return callback();
+        });
     }
 
     /**
@@ -528,33 +402,23 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricListMultipartUploadParts',
             bucket, timestamp,
         });
-        return this.ds.incr(
-            genBucketCounter(bucket, 'listMultipartUploadPartsCounter'),
-            (err, count) => {
-                if (err) {
-                    log.error('error incrementing counter', {
-                        method: 'UtapiClient.pushMetricListMultipartUpload' +
-                            'Parts',
-                        error: err,
-                    });
-                    return callback(err);
-                }
-                const cmds = [
-                    ['zremrangebyscore',
-                        genBucketKey(bucket, 'listMultipartUploadParts',
-                            timespan),
-                        timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'listMultipartUploadParts',
-                        timespan),
-                        timestamp, count],
-                ];
-                return this.ds.batch(cmds, callback);
-            });
+        const key = genBucketKey(bucket, 'listMultipartUploadParts', timestamp);
+        return this.ds.incr(key, err => {
+            if (err) {
+                log.error('error incrementing counter', {
+                    method: 'UtapiClient.pushMetricListMultipartUpload' +
+                        'Parts',
+                    error: err,
+                });
+                return callback(errors.InternalError);
+            }
+            return callback();
+        });
     }
 
     /**
@@ -570,28 +434,21 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricAbortMultipartUpload',
             bucket, timestamp,
         });
-        const key = genBucketCounter(bucket, 'abortMultipartUploadCounter');
-        return this.ds.incr(key, (err, count) => {
+        const key = genBucketKey(bucket, 'abortMultipartUpload', timestamp);
+        return this.ds.incr(key, err => {
             if (err) {
                 log.error('error incrementing counter', {
                     method: 'UtapiClient.pushMetricAbortMultipartUpload',
                     error: err,
                 });
-                return callback(err);
+                return callback(errors.InternalError);
             }
-            const cmds = [
-                ['zremrangebyscore',
-                    genBucketKey(bucket, 'abortMultipartUpload', timespan),
-                    timestamp, timestamp],
-                ['zadd', genBucketKey(bucket, 'abortMultipartUpload', timespan),
-                    timestamp, count],
-            ];
-            return this.ds.batch(cmds, callback);
+            return callback();
         });
     }
 
@@ -609,7 +466,7 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricDeleteObject',
             bucket, timestamp,
@@ -617,75 +474,56 @@ export default class UtapiClient {
         return this.ds.batch([
             ['decrby', genBucketCounter(bucket, 'storageUtilizedCounter'),
                 objectSize],
-            ['incr', genBucketCounter(bucket, 'deleteObjectCounter')],
             ['decr', genBucketCounter(bucket, 'numberOfObjectsCounter')],
+            ['incr', genBucketKey(bucket, 'deleteObject', timestamp)],
         ], (err, results) => {
-            if (err || results[0][0]) {
+            if (err) {
                 log.error('error incrementing counter', {
                     method: 'UtapiClient.pushMetricDeleteObject',
                     error: err,
                 });
-                return callback(err);
+                return callback(errors.InternalError);
             }
 
             const cmds = [];
             // storage utilized counter
             let actionErr = results[0][0];
-            let tempCounter = parseInt(results[0][1], 10);
-            tempCounter = tempCounter < 0 ? 0 : tempCounter;
             let actionCounter = parseInt(results[0][1], 10);
+            actionCounter = actionCounter < 0 ? 0 : actionCounter;
             if (actionErr) {
                 log.error('error incrementing counter for push metric', {
                     method: 'UtapiClient.pushMetricDeleteObject',
                     metric: 'storage utilized',
                     error: actionErr,
                 });
-            } else {
-                cmds.push(
-                    ['zremrangebyscore',
-                        genBucketStateKey(bucket, 'storageUtilized', timespan),
-                        timestamp, timestamp],
-                    ['zadd',
-                        genBucketStateKey(bucket, 'storageUtilized', timespan),
-                        timestamp, tempCounter]);
+                return callback(errors.InternalError);
             }
-
-            // del object counter
-            actionErr = results[1][0];
-            actionCounter = results[1][1];
-            if (actionErr) {
-                log.error('error incrementing counter for push metric', {
-                    method: 'UtapiClient.pushMetricDeleteObject',
-                    metric: 'delete object',
-                    error: actionErr,
-                });
-            } else {
-                cmds.push(
-                    ['zremrangebyscore',
-                        genBucketKey(bucket, 'deleteObject', timespan),
-                        timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'deleteObject', timespan),
-                        timestamp, actionCounter]);
-            }
+            cmds.push(
+                ['zremrangebyscore',
+                    genBucketStateKey(bucket, 'storageUtilized'),
+                    timestamp, timestamp],
+                ['zadd',
+                    genBucketStateKey(bucket, 'storageUtilized'),
+                    timestamp, actionCounter]);
 
             // num of objects counter
-            actionErr = results[2][0];
-            tempCounter = parseInt(results[2][1], 10);
-            tempCounter = tempCounter < 0 ? 0 : tempCounter;
+            actionErr = results[1][0];
+            actionCounter = parseInt(results[1][1], 10);
+            actionCounter = actionCounter < 0 ? 0 : actionCounter;
             if (actionErr) {
                 log.error('error incrementing counter for push metric', {
                     method: 'UtapiClient.pushMetricDeleteObject',
                     metric: 'num of objects',
                     error: actionErr,
                 });
-            } else {
-                cmds.push(
-                    ['zremrangebyscore',
-                        genBucketStateKey(bucket, 'numberOfObjects'), timestamp,
-                        timestamp],
-                    ['zadd', genBucketStateKey(bucket, 'numberOfObjects'),
-                        timestamp, tempCounter]);
+                return callback(errors.InternalError);
             }
+            cmds.push(
+                ['zremrangebyscore',
+                    genBucketStateKey(bucket, 'numberOfObjects'), timestamp,
+                    timestamp],
+                ['zadd', genBucketStateKey(bucket, 'numberOfObjects'),
+                    timestamp, actionCounter]);
             return this.ds.batch(cmds, callback);
         });
     }
@@ -704,59 +542,23 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricGetObject', bucket, timestamp });
         // update counters
         return this.ds.batch([
-            ['incrby', genBucketCounter(bucket, 'outgoingBytesCounter'),
-            objectSize],
-            ['incr', genBucketCounter(bucket, 'outgoingBytesCounter')],
-        ], (err, results) => {
+            ['incrby', genBucketKey(bucket, 'outgoingBytes', timestamp),
+                objectSize],
+            ['incr', genBucketKey(bucket, 'getObject', timestamp)],
+        ], err => {
             if (err) {
                 log.error('error pushing metric', {
                     method: 'UtapiClient.pushMetricGetObject',
                     error: err,
                 });
-                return callback(err);
+                return callback(errors.InternalError);
             }
-            const cmds = [];
-            // storage utilized counter
-            let actionErr = results[0][0];
-            let actionCounter = results[0][1];
-            if (actionErr) {
-                log.error('error incrementing counter for push metric', {
-                    method: 'UtapiClient.pushMetricGetObject',
-                    metric: 'outgoing bytes',
-                    error: actionErr,
-                });
-            } else {
-                cmds.push(
-                    ['zremrangebyscore',
-                        genBucketStateKey(bucket, 'outgoingBytes'),
-                        timestamp, timestamp],
-                    ['zadd', genBucketStateKey(bucket, 'outgoingBytes'),
-                        timestamp, actionCounter]);
-            }
-
-            // get object counter
-            actionErr = results[1][0];
-            actionCounter = results[1][1];
-            if (actionErr) {
-                log.error('error incrementing counter for push metric', {
-                    method: 'UtapiClient.pushMetricGetObject',
-                    metric: 'outgoing bytes',
-                    error: actionErr,
-                });
-            } else {
-                cmds.push(
-                    ['zremrangebyscore',
-                        genBucketKey(bucket, 'getObject', timespan),
-                        timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'getObject', timespan),
-                        timestamp, actionCounter]);
-            }
-            return this.ds.batch(cmds, callback);
+            return callback();
         });
     }
 
@@ -773,13 +575,13 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricGetObjectAcl',
             bucket, timestamp,
         });
-        const key = genBucketCounter(bucket, 'getObjectAclCounter');
-        return this.ds.incr(key, (err, count) => {
+        const key = genBucketKey(bucket, 'getObjectAcl', timestamp);
+        return this.ds.incr(key, err => {
             if (err) {
                 log.error('error incrementing counter', {
                     method: 'UtapiClient.pushMetricGetObjectAcl',
@@ -787,14 +589,7 @@ export default class UtapiClient {
                 });
                 return callback(err);
             }
-            const cmds = [
-                ['zremrangebyscore',
-                    genBucketKey(bucket, 'getObjectAcl', timespan), timestamp,
-                    timestamp],
-                ['zadd', genBucketKey(bucket, 'getObjectAcl', timespan),
-                    timestamp, count],
-            ];
-            return this.ds.batch(cmds, callback);
+            return callback();
         });
     }
 
@@ -815,7 +610,7 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         let numberOfObjectsCounter;
         // if previous object size is null then it's a new object in a bucket
         // or else it's an old object being overwritten
@@ -837,17 +632,17 @@ export default class UtapiClient {
         return this.ds.batch([
             ['incrby', genBucketCounter(bucket, 'storageUtilizedCounter'),
                 storageUtilizedDelta],
-            ['incrby', genBucketCounter(bucket, 'incomingBytesCounter'),
-                objectSize],
             numberOfObjectsCounter,
-            ['incr', genBucketCounter(bucket, 'putObjectCounter')],
+            ['incrby', genBucketKey(bucket, 'incomingBytes', timestamp),
+                objectSize],
+            ['incr', genBucketKey(bucket, 'putObject', timestamp)],
         ], (err, results) => {
             if (err) {
                 log.error('error pushing metric', {
                     method: 'UtapiClient.pushMetricPutObject',
                     error: err,
                 });
-                return callback(err);
+                return callback(errors.InternalError);
             }
             const cmds = [];
             let actionErr;
@@ -861,69 +656,32 @@ export default class UtapiClient {
                     metric: 'storage utilized',
                     error: actionErr,
                 });
-            } else {
-                cmds.push(
-                    ['zremrangebyscore',
-                        genBucketStateKey(bucket, 'storageUtilized', timespan),
-                        timestamp, timestamp],
-                    ['zadd',
-                        genBucketStateKey(bucket, 'storageUtilized', timespan),
-                        timestamp, actionCounter]);
+                return callback(errors.InternalError);
             }
-
-            // incoming bytes counter
-            actionErr = results[1][0];
-            actionCounter = results[1][1];
-            if (actionErr) {
-                log.error('error incrementing counter for push metric', {
-                    method: 'UtapiClient.pushMetricPutObject',
-                    metric: 'incoming bytes',
-                    error: actionErr,
-                });
-            } else {
-                cmds.push(
-                    ['zremrangebyscore',
-                        genBucketStateKey(bucket, 'incomingBytes'),
-                        timestamp, timestamp],
-                    ['zadd', genBucketStateKey(bucket, 'incomingBytes'),
-                        timestamp, actionCounter]);
-            }
+            cmds.push(
+                ['zremrangebyscore',
+                    genBucketStateKey(bucket, 'storageUtilized'),
+                    timestamp, timestamp],
+                ['zadd', genBucketStateKey(bucket, 'storageUtilized'),
+                    timestamp, actionCounter]);
 
             // number of objects counter
-            actionErr = results[2][0];
-            actionCounter = results[2][1];
+            actionErr = results[1][0];
+            actionCounter = results[1][1];
             if (actionErr) {
                 log.error('error incrementing counter for push metric', {
                     method: 'UtapiClient.pushMetricPutObject',
                     metric: 'number of objects',
                     error: actionErr,
                 });
-            } else {
-                cmds.push(
-                    ['zremrangebyscore',
-                        genBucketStateKey(bucket, 'numberOfObjects'),
-                        timestamp, timestamp],
-                    ['zadd', genBucketStateKey(bucket, 'numberOfObjects'),
-                        timestamp, actionCounter]);
+                return callback(errors.InternalError);
             }
-
-            // putObject counter
-            actionErr = results[3][0];
-            actionCounter = results[3][1];
-            if (actionErr) {
-                log.error('error incrementing counter for push metric', {
-                    method: 'UtapiClient.pushMetricPutObject',
-                    metric: 'put object',
-                    error: actionErr,
-                });
-            } else {
-                cmds.push(
-                    ['zremrangebyscore',
-                        genBucketKey(bucket, 'putObject', timespan),
-                        timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'putObject', timespan),
-                        timestamp, actionCounter]);
-            }
+            cmds.push(
+                ['zremrangebyscore',
+                    genBucketStateKey(bucket, 'numberOfObjects'),
+                    timestamp, timestamp],
+                ['zadd', genBucketStateKey(bucket, 'numberOfObjects'),
+                    timestamp, actionCounter]);
             return this.ds.batch(cmds, callback);
         });
     }
@@ -941,29 +699,22 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricPutObjectAcl',
             bucket, timestamp,
         });
-        return this.ds.incr(genBucketCounter(bucket, 'putObjectAclCounter'),
-            (err, count) => {
-                if (err) {
-                    log.error('error incrementing counter', {
-                        method: 'UtapiClient.pushMetricPutObjectAcl',
-                        error: err,
-                    });
-                    return callback(err);
-                }
-                const cmds = [
-                    ['zremrangebyscore',
-                        genBucketKey(bucket, 'putObjectAcl', timespan),
-                        timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'putObjectAcl', timespan),
-                        timestamp, count],
-                ];
-                return this.ds.batch(cmds, callback);
-            });
+        const key = genBucketKey(bucket, 'putObjectAcl', timestamp);
+        return this.ds.incr(key, err => {
+            if (err) {
+                log.error('error incrementing counter', {
+                    method: 'UtapiClient.pushMetricPutObjectAcl',
+                    error: err,
+                });
+                return callback(errors.InternalError);
+            }
+            return callback();
+        });
     }
 
     /**
@@ -979,29 +730,22 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricHeadBucket',
             bucket, timestamp,
         });
-        return this.ds.incr(genBucketCounter(bucket, 'headBucketCounter'),
-            (err, count) => {
-                if (err) {
-                    log.error('error incrementing counter', {
-                        method: 'UtapiClient.pushMetricHeadBucket',
-                        error: err,
-                    });
-                    return callback(err);
-                }
-                const cmds = [
-                    ['zremrangebyscore',
-                        genBucketKey(bucket, 'headBucket', timespan), timestamp,
-                        timestamp],
-                    ['zadd', genBucketKey(bucket, 'headBucket', timespan),
-                        timestamp, count],
-                ];
-                return this.ds.batch(cmds, callback);
-            });
+        const key = genBucketKey(bucket, 'headBucket', timestamp);
+        return this.ds.incr(key, err => {
+            if (err) {
+                log.error('error incrementing counter', {
+                    method: 'UtapiClient.pushMetricHeadBucket',
+                    error: err,
+                });
+                return callback(errors.InternalError);
+            }
+            return callback();
+        });
     }
 
     /**
@@ -1017,28 +761,21 @@ export default class UtapiClient {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const { timespan, timestamp } = UtapiClient.getNormalizedTime();
+        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricHeadObject',
             bucket, timestamp,
         });
-        return this.ds.incr(genBucketCounter(bucket, 'headObjectCounter'),
-            (err, count) => {
-                if (err) {
-                    log.error('error incrementing counter', {
-                        method: 'UtapiClient.pushMetricHeadObject',
-                        error: err,
-                    });
-                    return callback(err);
-                }
-                const cmds = [
-                    ['zremrangebyscore',
-                        genBucketKey(bucket, 'headObject', timespan),
-                        timestamp, timestamp],
-                    ['zadd', genBucketKey(bucket, 'headObject', timespan),
-                        timestamp, count],
-                ];
-                return this.ds.batch(cmds, callback);
-            });
+        const key = genBucketKey(bucket, 'headObject', timestamp);
+        return this.ds.incr(key, err => {
+            if (err) {
+                log.error('error incrementing counter', {
+                    method: 'UtapiClient.pushMetricHeadObject',
+                    error: err,
+                });
+                return callback(errors.InternalError);
+            }
+            return callback();
+        });
     }
 }

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2,40 +2,11 @@
 const bucketStateKeys = {
     storageUtilized: b => `s3:buckets:${b}:storageUtilized`,
     numberOfObjects: b => `s3:buckets:${b}:numberOfObjects`,
-    incomingBytes: b => `s3:buckets:${b}:incomingBytes`,
-    outgoingBytes: b => `s3:buckets:${b}:outgoingBytes`,
 };
 
 const bucketCounters = {
     storageUtilizedCounter: b => `s3:buckets:${b}:storageUtilized:counter`,
     numberOfObjectsCounter: b => `s3:buckets:${b}:numberOfObjects:counter`,
-    incomingBytesCounter: b => `s3:buckets:${b}:incomingBytes:counter`,
-    outgoingBytesCounter: b => `s3:buckets:${b}:outgoingBytes:counter`,
-    createBucketCounter: b => `s3:buckets:${b}:CreateBucket:counter`,
-    deleteBucketCounter: b => `s3:buckets:${b}:DeleteBucket:counter`,
-    listBucketCounter: b => `s3:buckets:${b}:ListBucket:counter`,
-    getBucketAclCounter: b => `s3:buckets:${b}:GetBucketAcl:counter`,
-    putBucketAclCounter: b => `s3:buckets:${b}:PutBucketAcl:counter`,
-    listBucketMultipartUploadsCounter: b =>
-        `s3:buckets:${b}:ListBucketMultipartUploads:counter`,
-    listMultipartUploadPartsCounter: b =>
-        `s3:buckets:${b}:ListMultipartUploadParts:counter`,
-    initiateMultipartUploadCounter: b =>
-        `s3:buckets:${b}:InitiateMultipartUpload:counter`,
-    completeMultipartUploadCounter: b =>
-        `s3:buckets:${b}:CompleteMultipartUpload:counter`,
-    abortMultipartUploadCounter: b =>
-        `s3:buckets:${b}:AbortMultipartUpload:counter`,
-    deleteObjectCounter: b => `s3:buckets:${b}:DeleteObject:counter`,
-    uploadPartCounter: b => `s3:buckets:${b}:UploadPart:counter`,
-    getObjectCounter: b => `s3:buckets:${b}:GetObject:counter`,
-    getObjectAclCounter: b => `s3:buckets:${b}:GetObjectAcl:counter`,
-    putObjectCounter: b => `s3:buckets:${b}:PutObject:counter`,
-    putObjectAclCounter: b => `s3:buckets:${b}:PutObjectAcl:counter`,
-    headBucketCounter: b => `s3:buckets:${b}:HeadBucket:counter`,
-    headObjectCounter: b => `s3:buckets:${b}:HeadObject:counter`,
-    listAllMyBucketsCounter: b =>
-        `s3:buckets:${b}:ListAllMyBuckets:counter`,
 };
 
 const bucketKeys = {
@@ -62,18 +33,19 @@ const bucketKeys = {
     putObjectAcl: (b, t) => `s3:buckets:${t}:${b}:PutObjectAcl`,
     headBucket: (b, t) => `s3:buckets:${t}:${b}:HeadBucket`,
     headObject: (b, t) => `s3:buckets:${t}:${b}:HeadObject`,
-    listAllMyBuckets: (b, t) => `s3:buckets:${t}:${b}:ListAllMyBuckets`,
+    incomingBytes: (b, t) => `s3:buckets:${t}:${b}:incomingBytes`,
+    outgoingBytes: (b, t) => `s3:buckets:${t}:${b}:outgoingBytes`,
 };
 
 /**
 * Returns the metric key in schema for the bucket
 * @param {string} bucket - bucket name
 * @param {string} metric - metric name
-* @param {number} timespan - unix timestamp normalized to the date
+* @param {number} timestamp - unix timestamp normalized to the nearest 15 min.
 * @return {string} - schema key
 */
-export function genBucketKey(bucket, metric, timespan) {
-    return bucketKeys[metric](bucket, timespan);
+export function genBucketKey(bucket, metric, timestamp) {
+    return bucketKeys[metric](bucket, timestamp);
 }
 
 /**
@@ -89,12 +61,12 @@ export function getBucketCounters(bucket) {
 /**
 * Returns a list of all keys for a bucket
 * @param {string} bucket - bucket name
-* @param {number} timespan - normalized timespan reduced to the day
+* @param {number} timestamp - unix timestamp normalized to the nearest 15 min.
 * @return {string[]} - list of keys
 */
-export function getBucketKeys(bucket, timespan) {
+export function getBucketKeys(bucket, timestamp) {
     return Object.keys(bucketKeys)
-        .map(item => bucketKeys[item](bucket, timespan));
+        .map(item => bucketKeys[item](bucket, timestamp));
 }
 
 /**

--- a/tests/functional/testUtapiClient.js
+++ b/tests/functional/testUtapiClient.js
@@ -21,11 +21,7 @@ function _assertCounters(bucket, cb) {
             }
             const metric = getMetricFromKey(item, bucket)
                 .replace(':counter', '');
-            if (item.indexOf('CreateBucket') !== -1) {
-                assert.equal(res, 1, `${metric} must be 1`);
-            } else {
-                assert.equal(res, 0, `${metric} must be 0`);
-            }
+            assert.equal(res, 0, `${metric} must be 0`);
             return next();
         }), cb);
 }
@@ -33,8 +29,7 @@ function _assertCounters(bucket, cb) {
 describe('Counters', () => {
     afterEach(() => memBackend.flushDb());
 
-    it('should set counters (other than create bucket counter) to 0 on' +
-        ' bucket creation', done => {
+    it('should set counters to 0 on bucket creation', done => {
         utapiClient.pushMetricCreateBucket(reqUid, testBucket,
             () => _assertCounters(testBucket, done));
     });

--- a/tests/unit/testBuckets.js
+++ b/tests/unit/testBuckets.js
@@ -10,37 +10,37 @@ const memBackend = new MemoryBackend();
 const datastore = new Datastore();
 datastore.setClient(memBackend);
 
-const expectedRes = {
-    bucketName: 'foo',
-    timeRange: [],
-    storageUtilized: [0, 0],
-    incomingBytes: 0,
-    outgoingBytes: 0,
-    numberOfObjects: [0, 0],
-    operations: {
-        's3:DeleteBucket': 0,
-        's3:ListBucket': 0,
-        's3:GetBucketAcl': 0,
-        's3:CreateBucket': 0,
-        's3:PutBucketAcl': 0,
-        's3:PutObject': 0,
-        's3:UploadPart': 0,
-        's3:ListBucketMultipartUploads': 0,
-        's3:ListMultipartUploadParts': 0,
-        's3:InitiateMultipartUpload': 0,
-        's3:CompleteMultipartUpload': 0,
-        's3:AbortMultipartUpload': 0,
-        's3:DeleteObject': 0,
-        's3:GetObject': 0,
-        's3:GetObjectAcl': 0,
-        's3:PutObjectAcl': 0,
-        's3:ListAllMyBuckets': 0,
-        's3:HeadBucket': 0,
-        's3:HeadObject': 0,
-    },
-};
-
-function assertMetrics(bucket, timeRange, props, done) {
+function assertMetrics(bucket, props, done) {
+    const timestamp = new Date().setMinutes(0, 0, 0);
+    const timeRange = [timestamp, timestamp];
+    const expectedRes = {
+        bucketName: 'foo',
+        timeRange: [],
+        storageUtilized: [0, 0],
+        incomingBytes: 0,
+        outgoingBytes: 0,
+        numberOfObjects: [0, 0],
+        operations: {
+            's3:DeleteBucket': 0,
+            's3:ListBucket': 0,
+            's3:GetBucketAcl': 0,
+            's3:CreateBucket': 0,
+            's3:PutBucketAcl': 0,
+            's3:PutObject': 0,
+            's3:UploadPart': 0,
+            's3:ListBucketMultipartUploads': 0,
+            's3:ListMultipartUploadParts': 0,
+            's3:InitiateMultipartUpload': 0,
+            's3:CompleteMultipartUpload': 0,
+            's3:AbortMultipartUpload': 0,
+            's3:DeleteObject': 0,
+            's3:GetObject': 0,
+            's3:GetObjectAcl': 0,
+            's3:PutObjectAcl': 0,
+            's3:HeadBucket': 0,
+            's3:HeadObject': 0,
+        },
+    };
     const expectedResProps = props || {};
     Buckets.getBucketMetrics(bucket, timeRange, datastore, logger,
         (err, res) => {
@@ -51,45 +51,106 @@ function assertMetrics(bucket, timeRange, props, done) {
                     expectedResProps.operations);
                 delete expectedResProps.operations;
             }
-            assert.deepStrictEqual(res, Object.assign({}, expectedRes,
+            assert.deepStrictEqual(res, Object.assign(expectedRes,
                 { timeRange }, expectedResProps));
             done();
         });
 }
 
+function testOps(keyIndex, metricindex, done) {
+    const timestamp = new Date().setMinutes(0, 0, 0);
+    let key;
+    let props = {};
+    let val;
+    if (keyIndex === 'storageUtilized' || keyIndex === 'numberOfObjects') {
+        key = genBucketStateKey(testBucket, keyIndex, timestamp);
+        val = 1024;
+        props[metricindex] = [val, val];
+        memBackend.zadd(key, timestamp, val, () =>
+            assertMetrics(testBucket, props, done));
+    } else if (keyIndex === 'incomingBytes' || keyIndex === 'outgoingBytes') {
+        key = genBucketKey(testBucket, keyIndex, timestamp);
+        val = 1024;
+        props[metricindex] = val;
+        memBackend.incrby(key, val, () =>
+            assertMetrics(testBucket, props, done));
+    } else {
+        key = genBucketKey(testBucket, keyIndex, timestamp);
+        val = 1;
+        props = { operations: {} };
+        props.operations[metricindex] = val;
+        memBackend.incr(key, () => assertMetrics(testBucket, props, done));
+    }
+}
+
 describe('Get Bucket Metrics', () => {
     afterEach(() => memBackend.flushDb());
 
-    it('should list default (0s) metrics of a bucket', done => {
-        const t = new Date();
-        t.setMinutes(0, 0, 0);
-        const timeStart = t.getTime();
-        assertMetrics(testBucket, [timeStart, timeStart], null, done);
-    });
+    it('should list default (0s) metrics of a bucket', done =>
+        assertMetrics(testBucket, null, done));
 
-    it('should return metrics for storage utilized', done => {
-        const key = genBucketStateKey(testBucket, 'storageUtilized');
-        const storageVal = 1024;
-        const t = new Date();
-        t.setMinutes(0, 0, 0);
-        const timeStart = t.getTime();
-        memBackend.zadd(key, timeStart, storageVal, () => {
-            assertMetrics(testBucket, [timeStart, timeStart], {
-                storageUtilized: [storageVal, storageVal],
-            }, done);
-        });
-    });
+    it('should return metrics for storage utilized', done =>
+        testOps('storageUtilized', 'storageUtilized', done));
 
-    it('should return metrics for list bucket', done => {
-        const val = 1;
-        const t = new Date();
-        t.setMinutes(0, 0, 0);
-        const timeStart = t.getTime();
-        const timespan = t.setHours(0);
-        const key = genBucketKey(testBucket, 'listBucket', timespan);
-        memBackend.zadd(key, timeStart, val, () => {
-            assertMetrics(testBucket, [timeStart, timeStart], {
-                operations: { 's3:ListBucket': 1 } }, done);
-        });
-    });
+    it('should return metrics for number of objects', done =>
+        testOps('numberOfObjects', 'numberOfObjects', done));
+
+    it('should return metrics for incoming bytes', done =>
+        testOps('incomingBytes', 'incomingBytes', done));
+
+    it('should return metrics for outgoing bytes', done =>
+        testOps('outgoingBytes', 'outgoingBytes', done));
+
+    it('should return metrics for delete bucket', done =>
+        testOps('deleteBucket', 's3:DeleteBucket', done));
+
+    it('should return metrics for list bucket', done =>
+        testOps('listBucket', 's3:ListBucket', done));
+
+    it('should return metrics for get bucket acl', done =>
+        testOps('getBucketAcl', 's3:GetBucketAcl', done));
+
+    it('should return metrics for put bucket acl', done =>
+        testOps('putBucketAcl', 's3:PutBucketAcl', done));
+
+    it('should return metrics for put object', done =>
+        testOps('putObject', 's3:PutObject', done));
+
+    it('should return metrics for upload part', done =>
+        testOps('uploadPart', 's3:UploadPart', done));
+
+    it('should return metrics for list bucket multipart uploads', done =>
+        testOps('listBucketMultipartUploads', 's3:ListBucketMultipartUploads',
+            done));
+
+    it('should return metrics for list multipart upload parts', done =>
+        testOps('listMultipartUploadParts', 's3:ListMultipartUploadParts',
+            done));
+
+    it('should return metrics for initiate multipart upload', done =>
+        testOps('initiateMultipartUpload', 's3:InitiateMultipartUpload', done));
+
+    it('should return metrics for complete multipart upload', done =>
+        testOps('completeMultipartUpload', 's3:CompleteMultipartUpload', done));
+
+    it('should return metrics for abort multipart upload', done =>
+        testOps('abortMultipartUpload', 's3:AbortMultipartUpload', done));
+
+    it('should return metrics for delete object', done =>
+        testOps('deleteObject', 's3:DeleteObject', done));
+
+    it('should return metrics for get object', done =>
+        testOps('getObject', 's3:GetObject', done));
+
+    it('should return metrics for get object acl', done =>
+        testOps('getObjectAcl', 's3:GetObjectAcl', done));
+
+    it('should return metrics for put object acl', done =>
+        testOps('putObjectAcl', 's3:PutObjectAcl', done));
+
+    it('should return metrics for head bucket', done =>
+        testOps('headBucket', 's3:HeadBucket', done));
+
+    it('should return metrics for head object', done =>
+        testOps('headObject', 's3:HeadObject', done));
 });

--- a/utils/getTimespan.js
+++ b/utils/getTimespan.js
@@ -1,9 +1,0 @@
-/**
-* Takes a timestamp and normalizes it to the day by removing hours, minutes,
-* seconds and milliseconds
-* @param {number} timestamp - unix timestamp
-* @return {number} timespan - timestamp normalized to the day
-*/
-export default function getTimespan(timestamp) {
-    return new Date(timestamp).setHours(0, 0, 0, 0);
-}


### PR DESCRIPTION
PR #37 of reducing the time precision introduced a bug which made
calculating operations incorrectly. As the code no longer adds multiple
members for the same timestamp (counters are updated for the normalized
timestamp), the solution has been simplified as follows

- All keys which hold operations counters (put object, create bucket etc.)
  use string keys instead of sorted sets

- INCR cmd is issued for the normalized timestamp on key on every push
  metric

- Total number of operations between start and end timestamps is the sum
  of counts held by the keys that fall between the two timestamps

- As sorted sets are no longer used for operations, there is no need for
  global counters for these keys, hence they are removed

- The only metrics which use sorted sets are the ones holding bucket state
  data - storage utilized and number of objects. Sorted sets are the best
  candidates for finding the nearest neighbor values

Fix #44