### PR TITLE
ft: use hiredis parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "start": "node index.js",
     "test": "mocha --compilers js:babel-core/register --recursive tests/unit"
   },
-  "private": true
+  "private": true,
+  "optionalDependencies": {
+    "hiredis": "^0.5.0"
+  }
 }

--- a/src/utils/redisClient.js
+++ b/src/utils/redisClient.js
@@ -1,5 +1,14 @@
 import Redis from 'ioredis';
 
+function _moduleCheck() {
+    try {
+        require.resolve('hiredis');
+    } catch (e) {
+        return false;
+    }
+    return true;
+}
+
 /**
 * Creates a new Redis client instance
 * @param {object} config - redis configuration
@@ -12,6 +21,10 @@ export default function redisClient(config, log) {
         enableOfflineQueue: false,
         // keep alive 3 seconds
         keepAlive: 3000,
+        // dropBufferSupport option performs better with
+        // hiredis (native redis module) and not with the default
+        // javascript redis parser
+        dropBufferSupport: _moduleCheck(),
     }, config));
     redisClient.on('error', err => log.trace('error with redis client', {
         error: err,


### PR DESCRIPTION
hiredis is a native C module for redis-cli. Cosbench tests showed this module performed
marginally better than the default javascript parser. ioredis module uses hiredis if it's
installed or reverts to it's in-built javascript parser.

The dropBufferSupport option prefers strings over buffers for replies and hiredis has
better performance with this option enabled.

Module is being installed as an optional dependency to favor open source installs on
machines which may not have gcc / g++ / python installed.