### PR TITLE
ft: utapi healthcheck route

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,9 @@
 {
     "port": 8100,
     "workers": 10,
+    "healthChecks": {
+        "allowFrom": ["127.0.0.1/8", "::1"]
+    },
     "log": {
         "logLevel": "info",
         "dumpLevel": "error"

--- a/src/lib/Config.js
+++ b/src/lib/Config.js
@@ -58,6 +58,20 @@ class Config {
             }
         }
 
+        this.healthChecks = { allowFrom: ['127.0.0.1/8', '::1'] };
+        if (config.healthChecks && config.healthChecks.allowFrom) {
+            assert(Array.isArray(config.healthChecks.allowFrom),
+                'config: invalid healthcheck configuration. allowFrom must ' +
+                'be an array');
+            config.healthChecks.allowFrom.forEach(item => {
+                assert(typeof item === 'string',
+                'config: invalid healthcheck configuration. allowFrom IP ' +
+                'address must be a string');
+            });
+            // augment to the defaults
+            this.healthChecks.allowFrom = this.healthChecks.allowFrom.concat(
+                config.healthChecks.allowFrom);
+        }
         // default to standalone configuration
         this.redis = { host: '127.0.0.1', port: 6379 };
         if (config.redis) {


### PR DESCRIPTION
This commit adds a healthcheck route bypassing the traditional router.
The route responds back with 200 if the server has a successful connection to
Redis and 500 if not. Additionally, the router checks IP address from the request
and denies any IP not whitelisted.