### PR TITLE
Refactor/utapi client

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,44 @@
 
 Service Utilization API for tracking resource usage and metrics reporting
 
+## Client
+
+The module exposes a client, named UtapiClient. Projects can use this client to
+push metrics directly to the underlying datastore(Redis) without the need of an
+extra HTTP request to Utapi.
+
+```
+import { UtapiClient } from 'utapi';
+
+const config = {
+    redis: {
+        host: '127.0.0.1',
+        port: 6379
+    }
+}
+const c = new UtapiClient(config);
+
+c.pushMetric('createBucket', '3d534b1511e5630e68f0', { bucket: 'demo' });
+
+c.pushMetric('putObject', '3d534b1511e5630e68f0', {
+    bucket: 'demo',
+    newByteLength: 1024,
+});
+
+c.pushMetric('putObject', '3d534b1511e5630e68f0', {
+    bucket: 'demo',
+    newByteLength: 1024,
+    oldByteLength: 256,
+});
+
+c.pushMetric('multiObjectDelete', '3d534b1511e5630e68f0', {
+    bucket: 'demo',
+    newByteLength: 1024,
+    oldByteLength: 256,
+    objectsCount: 999,
+});
+```
+
 ## Guidelines
 
 Please read our coding and workflow guidelines at

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The module exposes a client, named UtapiClient. Projects can use this client to
 push metrics directly to the underlying datastore(Redis) without the need of an
 extra HTTP request to Utapi.
 
-```
+```js
 import { UtapiClient } from 'utapi';
 
 const config = {
@@ -39,9 +39,8 @@ c.pushMetric('putObject', '3d534b1511e5630e68f0', {
 
 c.pushMetric('multiObjectDelete', '3d534b1511e5630e68f0', {
     bucket: 'demo',
-    newByteLength: 1024,
-    oldByteLength: 256,
-    objectsCount: 999,
+    byteLength: 1024,
+    numberOfObjects: 999,
 });
 ```
 

--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,8 @@ general:
 machine:
     node:
         version: 4.5.0
+    services:
+        - redis
 test:
     override:
         - npm run --silent lint_md

--- a/src/lib/UtapiClient.js
+++ b/src/lib/UtapiClient.js
@@ -5,6 +5,28 @@ import { genBucketKey, genBucketCounter, getBucketCounters, genBucketStateKey }
 import { errors } from 'arsenal';
 import redisClient from '../utils/redisClient';
 
+const methods = {
+    createBucket: '_pushMetricCreateBucket',
+    deleteBucket: '_pushMetricDeleteBucket',
+    listBucket: '_pushMetricListBucket',
+    getBucketAcl: '_pushMetricGetBucketAcl',
+    putBucketAcl: '_pushMetricPutBucketAcl',
+    uploadPart: '_pushMetricUploadPart',
+    initiateMultipartUpload: '_pushMetricInitiateMultipartUpload',
+    completeMultipartUpload: '_pushMetricCompleteMultipartUpload',
+    listMultipartUploads: '_pushMetricListBucketMultipartUploads',
+    listMultipartUploadParts: '_pushMetricListMultipartUploadParts',
+    abortMultipartUpload: '_pushMetricAbortMultipartUpload',
+    deleteObject: '_pushMetricDeleteObject',
+    multiObjectDelete: '_pushMetricMultiObjectDelete',
+    getObject: '_pushMetricGetObject',
+    getObjectAcl: '_pushMetricGetObjectAcl',
+    putObject: '_pushMetricPutObject',
+    copyObject: '_pushMetricCopyObject',
+    putObjectAcl: '_pushMetricPutObjectAcl',
+    headBucket: '_pushMetricHeadBucket',
+    headObject: '_pushMetricHeadObject',
+};
 export default class UtapiClient {
     constructor(config) {
         this.disableClient = true;
@@ -54,20 +76,42 @@ export default class UtapiClient {
     _noop() {}
 
     /**
-    * Updates counter for CreateBucket action on a Bucket resource. Since create
-    * bucket occcurs only once in a bucket's lifetime, counter is  always 1
+    * Generic method exposed by the client to push a metric with some values
+    * params can be expanded to provide metrics for other granularities
+    * (e.g. service, account, user).
+    * @param {string} metric - metric to be published
     * @param {string} reqUid - Request Unique Identifier
-    * @param {string} bucket - bucket name
+    * @param {object} params - params object
+    * @param {string} params.bucket - bucket name
+    * @param {string} params.newByteLength - new object size
+    * @param {string} params.oldByteLength - old object size (obj. overwrites)
+    * @param {string} params.numberOfObjects - number of obects added/deleted
     * @param {callback} [cb] - (optional) callback to call
-    * @return {undefined}
+    * @return {object} this - current instance
     */
-    pushMetricCreateBucket(reqUid, bucket, cb) {
+    pushMetric(metric, reqUid, params, cb) {
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
         const timestamp = UtapiClient.getNormalizedTimestamp();
+        this[methods[metric]](params, timestamp, log, callback);
+        return this;
+    }
+
+    /**
+    * Updates counter for CreateBucket action on a Bucket resource. Since create
+    * bucket occcurs only once in a bucket's lifetime, counter is  always 1
+    * @param {object} params - params for the metrics
+    * @param {object} params.bucket - bucket name
+    * @param {number} timestamp - normalized timestamp of current time
+    * @param {object} log - Werelogs request logger
+    * @param {callback} callback - callback to call
+    * @return {undefined}
+    */
+    _pushMetricCreateBucket(params, timestamp, log, callback) {
+        const { bucket } = params;
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricCreateBucket',
             bucket, timestamp,
@@ -102,18 +146,15 @@ export default class UtapiClient {
 
     /**
     * Updates counter for DeleteBucket action on a Bucket resource
-    * @param {string} reqUid - Request Unique Identifier
-    * @param {string} bucket - bucket name
-    * @param {callback} [cb] - (optional) callback to call
+    * @param {object} params - params for the metrics
+    * @param {object} params.bucket - bucket name
+    * @param {number} timestamp - normalized timestamp of current time
+    * @param {object} log - Werelogs request logger
+    * @param {callback} callback - callback to call
     * @return {undefined}
     */
-    pushMetricDeleteBucket(reqUid, bucket, cb) {
-        const callback = cb || this._noop;
-        if (this.disableClient) {
-            return callback();
-        }
-        const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+    _pushMetricDeleteBucket(params, timestamp, log, callback) {
+        const { bucket } = params;
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricDeleteBucket',
             bucket, timestamp,
@@ -163,18 +204,15 @@ export default class UtapiClient {
 
     /**
     * Updates counter for ListBucket action on a Bucket resource.
-    * @param {string} reqUid - Request Unique Identifier
-    * @param {string} bucket - bucket name
-    * @param {callback} [cb] - (optional) callback to call
+    * @param {object} params - params for the metrics
+    * @param {object} params.bucket - bucket name
+    * @param {number} timestamp - normalized timestamp of current time
+    * @param {object} log - Werelogs request logger
+    * @param {callback} callback - callback to call
     * @return {undefined}
     */
-    pushMetricListBucket(reqUid, bucket, cb) {
-        const callback = cb || this._noop;
-        if (this.disableClient) {
-            return callback();
-        }
-        const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+    _pushMetricListBucket(params, timestamp, log, callback) {
+        const { bucket } = params;
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricListBucket',
             bucket, timestamp,
@@ -194,18 +232,15 @@ export default class UtapiClient {
 
     /**
     * Updates counter for GetBucketAcl action on a Bucket resource.
-    * @param {string} reqUid - Request Unique Identifier
-    * @param {string} bucket - bucket name
-    * @param {callback} [cb] - (optional) callback to call
+    * @param {object} params - params for the metrics
+    * @param {object} params.bucket - bucket name
+    * @param {number} timestamp - normalized timestamp of current time
+    * @param {object} log - Werelogs request logger
+    * @param {callback} callback - callback to call
     * @return {undefined}
     */
-    pushMetricGetBucketAcl(reqUid, bucket, cb) {
-        const callback = cb || this._noop;
-        if (this.disableClient) {
-            return callback();
-        }
-        const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+    _pushMetricGetBucketAcl(params, timestamp, log, callback) {
+        const { bucket } = params;
         log.trace('pushing metric', { method: 'UtapiClient.pushMetricGet' +
             'BucketAcl',
             bucket, timestamp });
@@ -254,18 +289,15 @@ export default class UtapiClient {
 
     /**
     * Updates counter for PutBucketAcl action on a Bucket resource.
-    * @param {string} reqUid - Request Unique Identifier
-    * @param {string} bucket - bucket name
-    * @param {callback} [cb] - (optional) callback to call
+    * @param {object} params - params for the metrics
+    * @param {object} params.bucket - bucket name
+    * @param {number} timestamp - normalized timestamp of current time
+    * @param {object} log - Werelogs request logger
+    * @param {callback} callback - callback to call
     * @return {undefined}
     */
-    pushMetricPutBucketAcl(reqUid, bucket, cb) {
-        const callback = cb || this._noop;
-        if (this.disableClient) {
-            return callback();
-        }
-        const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+    _pushMetricPutBucketAcl(params, timestamp, log, callback) {
+        const { bucket } = params;
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricPutBucketAcl', bucket, timestamp });
         const key = genBucketKey(bucket, 'putBucketAcl', timestamp);
@@ -313,27 +345,24 @@ export default class UtapiClient {
 
     /**
     * Updates counter for UploadPart action on an object in a Bucket resource.
-    * @param {string} reqUid - Request Unique Identifier
-    * @param {string} bucket - bucket name
-    * @param {number} objectSize - size of object in bytes
-    * @param {callback} [cb] - (optional) callback to call
+    * @param {object} params - params for the metrics
+    * @param {object} params.bucket - bucket name
+    * @param {number} params.newByteLength - size of object in bytes
+    * @param {number} timestamp - normalized timestamp of current time
+    * @param {object} log - Werelogs request logger
+    * @param {callback} callback - callback to call
     * @return {undefined}
     */
-    pushMetricUploadPart(reqUid, bucket, objectSize, cb) {
-        const callback = cb || this._noop;
-        if (this.disableClient) {
-            return callback();
-        }
-        const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+    _pushMetricUploadPart(params, timestamp, log, callback) {
+        const { bucket, newByteLength } = params;
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricUploadPart', bucket, timestamp });
         // update counters
         return this.ds.batch([
             ['incrby', genBucketCounter(bucket, 'storageUtilizedCounter'),
-                objectSize],
+                newByteLength],
             ['incrby', genBucketKey(bucket, 'incomingBytes', timestamp),
-                objectSize],
+                newByteLength],
             ['incr', genBucketKey(bucket, 'uploadPart', timestamp)],
         ], (err, results) => {
             if (err) {
@@ -367,18 +396,15 @@ export default class UtapiClient {
 
     /**
     * Updates counter for Initiate Multipart Upload action on a Bucket resource.
-    * @param {string} reqUid - Request Unique Identifier
-    * @param {string} bucket - bucket name
-    * @param {callback} [cb] - (optional) callback to call
+    * @param {object} params - params for the metrics
+    * @param {object} params.bucket - bucket name
+    * @param {number} timestamp - normalized timestamp of current time
+    * @param {object} log - Werelogs request logger
+    * @param {callback} callback - callback to call
     * @return {undefined}
     */
-    pushMetricInitiateMultipartUpload(reqUid, bucket, cb) {
-        const callback = cb || this._noop;
-        if (this.disableClient) {
-            return callback();
-        }
-        const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+    _pushMetricInitiateMultipartUpload(params, timestamp, log, callback) {
+        const { bucket } = params;
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricInitiateMultipartUpload',
             bucket, timestamp,
@@ -398,18 +424,15 @@ export default class UtapiClient {
 
     /**
     * Updates counter for Complete Multipart Upload action on a Bucket resource.
-    * @param {string} reqUid - Request Unique Identifier
-    * @param {string} bucket - bucket name
-    * @param {callback} [cb] - (optional) callback to call
+    * @param {object} params - params for the metrics
+    * @param {object} params.bucket - bucket name
+    * @param {number} timestamp - normalized timestamp of current time
+    * @param {object} log - Werelogs request logger
+    * @param {callback} callback - callback to call
     * @return {undefined}
     */
-    pushMetricCompleteMultipartUpload(reqUid, bucket, cb) {
-        const callback = cb || this._noop;
-        if (this.disableClient) {
-            return callback();
-        }
-        const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+    _pushMetricCompleteMultipartUpload(params, timestamp, log, callback) {
+        const { bucket } = params;
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricCompleteMultipartUpload',
             bucket, timestamp,
@@ -448,18 +471,15 @@ export default class UtapiClient {
 
     /**
     * Updates counter for ListMultipartUploads action on a Bucket resource.
-    * @param {string} reqUid - Request Unique Identifier
-    * @param {string} bucket - bucket name
-    * @param {callback} [cb] - (optional) callback to call
+    * @param {object} params - params for the metrics
+    * @param {object} params.bucket - bucket name
+    * @param {number} timestamp - normalized timestamp of current time
+    * @param {object} log - Werelogs request logger
+    * @param {callback} callback - callback to call
     * @return {undefined}
     */
-    pushMetricListBucketMultipartUploads(reqUid, bucket, cb) {
-        const callback = cb || this._noop;
-        if (this.disableClient) {
-            return callback();
-        }
-        const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+    _pushMetricListBucketMultipartUploads(params, timestamp, log, callback) {
+        const { bucket } = params;
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricListBucketMultipartUploads',
             bucket, timestamp,
@@ -481,18 +501,15 @@ export default class UtapiClient {
 
     /**
     * Updates counter for ListMultipartUploadParts action on a Bucket resource.
-    * @param {string} reqUid - Request Unique Identifier
-    * @param {string} bucket - bucket name
-    * @param {callback} [cb] - (optional) callback to call
+    * @param {object} params - params for the metrics
+    * @param {object} params.bucket - bucket name
+    * @param {number} timestamp - normalized timestamp of current time
+    * @param {object} log - Werelogs request logger
+    * @param {callback} callback - callback to call
     * @return {undefined}
     */
-    pushMetricListMultipartUploadParts(reqUid, bucket, cb) {
-        const callback = cb || this._noop;
-        if (this.disableClient) {
-            return callback();
-        }
-        const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+    _pushMetricListMultipartUploadParts(params, timestamp, log, callback) {
+        const { bucket } = params;
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricListMultipartUploadParts',
             bucket, timestamp,
@@ -513,18 +530,15 @@ export default class UtapiClient {
 
     /**
     * Updates counter for AbortMultipartUpload action on a Bucket resource.
-    * @param {string} reqUid - Request Unique Identifier
-    * @param {string} bucket - bucket name
-    * @param {callback} [cb] - (optional) callback to call
+    * @param {object} params - params for the metrics
+    * @param {object} params.bucket - bucket name
+    * @param {number} timestamp - normalized timestamp of current time
+    * @param {object} log - Werelogs request logger
+    * @param {callback} callback - callback to call
     * @return {undefined}
     */
-    pushMetricAbortMultipartUpload(reqUid, bucket, cb) {
-        const callback = cb || this._noop;
-        if (this.disableClient) {
-            return callback();
-        }
-        const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+    _pushMetricAbortMultipartUpload(params, timestamp, log, callback) {
+        const { bucket } = params;
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricAbortMultipartUpload',
             bucket, timestamp,
@@ -544,32 +558,28 @@ export default class UtapiClient {
 
     /**
     * Updates counter for DeleteObject or MultiObjectDelete action
-    * @param {string} reqUid - Request Unique Identifier
-    * @param {string} bucket - bucket name
-    * @param {number} objectSize - size of the object(s)
-    * @param {number} numOfObjects - number of objects deleted
-    * @param {callback} [cb] - (optional) callback to call
+    * @param {object} params - params for the metrics
+    * @param {object} params.bucket - bucket name
+    * @param {number} params.newByteLength - size of the object(s)
+    * @param {number} params.numberOfObjects - number of objects deleted
+    * @param {number} timestamp - normalized timestamp of current time
+    * @param {object} log - Werelogs request logger
+    * @param {callback} callback - callback to call
     * @return {undefined}
     */
-    _genericPushMetricDeleteObject(reqUid, bucket, objectSize,
-        numOfObjects, cb) {
-        const callback = cb || this._noop;
-        if (this.disableClient) {
-            return callback();
-        }
-        const bucketAction = numOfObjects === 1 ? 'deleteObject'
+    _genericPushMetricDeleteObject(params, timestamp, log, callback) {
+        const { bucket, newByteLength, numberOfObjects } = params;
+        const bucketAction = numberOfObjects === 1 ? 'deleteObject'
             : 'multiObjectDelete';
-        const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
         log.trace('pushing metric', {
             method: 'UtapiClient._genericPushMetricDeleteObject',
             bucket, timestamp,
         });
         return this.ds.batch([
             ['decrby', genBucketCounter(bucket, 'storageUtilizedCounter'),
-                objectSize],
+                newByteLength],
             ['decrby', genBucketCounter(bucket, 'numberOfObjectsCounter'),
-                numOfObjects],
+                numberOfObjects],
             ['incr', genBucketKey(bucket, bucketAction, timestamp)],
         ], (err, results) => {
             if (err) {
@@ -626,54 +636,54 @@ export default class UtapiClient {
 
     /**
     * Updates counter for DeleteObject action on an object of Bucket resource.
-    * @param {string} reqUid - Request Unique Identifier
-    * @param {string} bucket - bucket name
-    * @param {number} objectSize - size of the object deleted
-    * @param {callback} [cb] - (optional) callback to call
+    * @param {object} params - params for the metrics
+    * @param {object} params.bucket - bucket name
+    * @param {number} params.newByteLength - size of the object deleted
+    * @param {number} params.objectsCount - number of objects deleted
+    * @param {number} timestamp - normalized timestamp of current time
+    * @param {object} log - Werelogs request logger
+    * @param {callback} callback - callback to call
     * @return {undefined}
     */
-    pushMetricDeleteObject(reqUid, bucket, objectSize, cb) {
-        this._genericPushMetricDeleteObject(reqUid, bucket, objectSize,
-            1, cb);
+    _pushMetricDeleteObject(params, timestamp, log, callback) {
+        this._genericPushMetricDeleteObject(params, timestamp, log, callback);
         return undefined;
     }
 
     /**
     * Updates counter for MultiObjectDelete action
-    * @param {string} reqUid - Request Unique Identifier
-    * @param {string} bucket - bucket name
-    * @param {number} objectSize - total size of the objects deleted
-    * @param {number} numOfObjects - number of objects deleted
-    * @param {callback} [cb] - (optional) callback to call
+    * @param {object} params - params for the metrics
+    * @param {object} params.bucket - bucket name
+    * @param {number} params.newByteLength - size of the object deleted
+    * @param {number} params.objectsCount - number of objects deleted
+    * @param {number} timestamp - normalized timestamp of current time
+    * @param {object} log - Werelogs request logger
+    * @param {callback} callback - callback to call
     * @return {undefined}
     */
-    pushMetricMultiObjectDelete(reqUid, bucket, objectSize, numOfObjects, cb) {
-        this._genericPushMetricDeleteObject(reqUid, bucket, objectSize,
-            numOfObjects, cb);
+    _pushMetricMultiObjectDelete(params, timestamp, log, callback) {
+        this._genericPushMetricDeleteObject(params, timestamp, log, callback);
         return undefined;
     }
 
     /**
     * Updates counter for GetObject action on an object in a Bucket resource.
-    * @param {string} reqUid - Request Unique Identifier
-    * @param {string} bucket - bucket name
-    * @param {number} objectSize - size of object in bytes
-    * @param {callback} [cb] - (optional) callback to call
+    * @param {object} params - params for the metrics
+    * @param {object} params.bucket - bucket name
+    * @param {number} params.newByteLength - size of object in bytes
+    * @param {number} timestamp - normalized timestamp of current time
+    * @param {object} log - Werelogs request logger
+    * @param {callback} callback - callback to call
     * @return {undefined}
     */
-    pushMetricGetObject(reqUid, bucket, objectSize, cb) {
-        const callback = cb || this._noop;
-        if (this.disableClient) {
-            return callback();
-        }
-        const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+    _pushMetricGetObject(params, timestamp, log, callback) {
+        const { bucket, newByteLength } = params;
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricGetObject', bucket, timestamp });
         // update counters
         return this.ds.batch([
             ['incrby', genBucketKey(bucket, 'outgoingBytes', timestamp),
-                objectSize],
+                newByteLength],
             ['incr', genBucketKey(bucket, 'getObject', timestamp)],
         ], err => {
             if (err) {
@@ -689,18 +699,15 @@ export default class UtapiClient {
 
     /**
     * Updates counter for GetObjectAcl action on a Bucket resource.
-    * @param {string} reqUid - Request Unique Identifier
-    * @param {string} bucket - bucket name
-    * @param {callback} [cb] - (optional) callback to call
+    * @param {object} params - params for the metrics
+    * @param {object} params.bucket - bucket name
+    * @param {number} timestamp - normalized timestamp of current time
+    * @param {object} log - Werelogs request logger
+    * @param {callback} callback - callback to call
     * @return {undefined}
     */
-    pushMetricGetObjectAcl(reqUid, bucket, cb) {
-        const callback = cb || this._noop;
-        if (this.disableClient) {
-            return callback();
-        }
-        const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+    _pushMetricGetObjectAcl(params, timestamp, log, callback) {
+        const { bucket } = params;
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricGetObjectAcl',
             bucket, timestamp,
@@ -721,34 +728,31 @@ export default class UtapiClient {
 
     /**
     * Updates counter for PutObject action on an object in a Bucket resource.
-    * @param {string} reqUid - Request Unique Identifier
-    * @param {string} bucket - bucket name
-    * @param {number} objectSize - size of object in bytes
-    * @param {number} prevObjectSize - previous size of object in bytes if this
-    * action overwrote an existing object
-    * @param {callback} [cb] - (optional) callback to call
+    * @param {object} params - params for the metrics
+    * @param {object} params.bucket - bucket name
+    * @param {number} params.newByteLength - size of object in bytes
+    * @param {number} params.oldByteLength - previous size of object in bytes
+    * if this action overwrote an existing object
+    * @param {number} timestamp - normalized timestamp of current time
+    * @param {object} log - Werelogs request logger
+    * @param {callback} callback - callback to call
     * @return {undefined}
     */
-    pushMetricPutObject(reqUid, bucket, objectSize, prevObjectSize, cb) {
-        const callback = cb || this._noop;
-        if (this.disableClient) {
-            return callback();
-        }
-        const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+    _pushMetricPutObject(params, timestamp, log, callback) {
+        const { bucket, newByteLength, oldByteLength } = params;
         let numberOfObjectsCounter;
         // if previous object size is null then it's a new object in a bucket
         // or else it's an old object being overwritten
-        if (prevObjectSize === null) {
+        if (oldByteLength === null) {
             numberOfObjectsCounter = ['incr', genBucketCounter(bucket,
                 'numberOfObjectsCounter')];
         } else {
             numberOfObjectsCounter = ['get', genBucketCounter(bucket,
                 'numberOfObjectsCounter')];
         }
-        let oldObjSize = parseInt(prevObjectSize, 10);
+        let oldObjSize = parseInt(oldByteLength, 10);
         oldObjSize = isNaN(oldObjSize) ? 0 : oldObjSize;
-        let newObjSize = parseInt(objectSize, 10);
+        let newObjSize = parseInt(newByteLength, 10);
         newObjSize = isNaN(newObjSize) ? 0 : newObjSize;
         const storageUtilizedDelta = newObjSize - oldObjSize;
         log.trace('pushing metric',
@@ -759,7 +763,7 @@ export default class UtapiClient {
                 storageUtilizedDelta],
             numberOfObjectsCounter,
             ['incrby', genBucketKey(bucket, 'incomingBytes', timestamp),
-                objectSize],
+                newByteLength],
             ['incr', genBucketKey(bucket, 'putObject', timestamp)],
         ], (err, results) => {
             if (err) {
@@ -813,34 +817,31 @@ export default class UtapiClient {
 
     /**
     * Updates counter for CopyObject action on an object in a Bucket resource.
-    * @param {string} reqUid - Request Unique Identifier
-    * @param {string} bucket - bucket name
-    * @param {number} objectSize - size of object in bytes
-    * @param {number} prevObjectSize - previous size of object in bytes if this
-    * action overwrote an existing object
-    * @param {callback} [cb] - (optional) callback to call
+    * @param {object} params - params for the metrics
+    * @param {object} params.bucket - bucket name
+    * @param {number} params.newByteLength - size of object in bytes
+    * @param {number} params.oldByteLength - previous size of object in bytes
+    * if this action overwrote an existing object
+    * @param {number} timestamp - normalized timestamp of current time
+    * @param {object} log - Werelogs request logger
+    * @param {callback} callback - callback to call
     * @return {undefined}
     */
-    pushMetricCopyObject(reqUid, bucket, objectSize, prevObjectSize, cb) {
-        const callback = cb || this._noop;
-        if (this.disableClient) {
-            return callback();
-        }
-        const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+    _pushMetricCopyObject(params, timestamp, log, callback) {
+        const { bucket, newByteLength, oldByteLength } = params;
         let numberOfObjectsCounter;
         // if previous object size is null then it's a new object in a bucket
         // or else it's an old object being overwritten
-        if (prevObjectSize === null) {
+        if (oldByteLength === null) {
             numberOfObjectsCounter = ['incr', genBucketCounter(bucket,
                 'numberOfObjectsCounter')];
         } else {
             numberOfObjectsCounter = ['get', genBucketCounter(bucket,
                 'numberOfObjectsCounter')];
         }
-        let oldObjSize = parseInt(prevObjectSize, 10);
+        let oldObjSize = parseInt(oldByteLength, 10);
         oldObjSize = isNaN(oldObjSize) ? 0 : oldObjSize;
-        let newObjSize = parseInt(objectSize, 10);
+        let newObjSize = parseInt(newByteLength, 10);
         newObjSize = isNaN(newObjSize) ? 0 : newObjSize;
         const storageUtilizedDelta = newObjSize - oldObjSize;
         log.trace('pushing metric',
@@ -903,18 +904,15 @@ export default class UtapiClient {
 
     /**
     * Updates counter for PutObjectAcl action on a Bucket resource.
-    * @param {string} reqUid - Request Unique Identifier
-    * @param {string} bucket - bucket name
-    * @param {callback} [cb] - (optional) callback to call
+    * @param {object} params - params for the metrics
+    * @param {object} params.bucket - bucket name
+    * @param {number} timestamp - normalized timestamp of current time
+    * @param {object} log - Werelogs request logger
+    * @param {callback} callback - callback to call
     * @return {undefined}
     */
-    pushMetricPutObjectAcl(reqUid, bucket, cb) {
-        const callback = cb || this._noop;
-        if (this.disableClient) {
-            return callback();
-        }
-        const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+    _pushMetricPutObjectAcl(params, timestamp, log, callback) {
+        const { bucket } = params;
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricPutObjectAcl',
             bucket, timestamp,
@@ -934,18 +932,15 @@ export default class UtapiClient {
 
     /**
     * Updates counter for HeadBucket action on a Bucket resource.
-    * @param {string} reqUid - Request Unique Identifier
-    * @param {string} bucket - bucket name
-    * @param {callback} [cb] - (optional) callback to call
+    * @param {object} params - params for the metrics
+    * @param {object} params.bucket - bucket name
+    * @param {number} timestamp - normalized timestamp of current time
+    * @param {object} log - Werelogs request logger
+    * @param {callback} callback - callback to call
     * @return {undefined}
     */
-    pushMetricHeadBucket(reqUid, bucket, cb) {
-        const callback = cb || this._noop;
-        if (this.disableClient) {
-            return callback();
-        }
-        const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+    _pushMetricHeadBucket(params, timestamp, log, callback) {
+        const { bucket } = params;
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricHeadBucket',
             bucket, timestamp,
@@ -965,18 +960,15 @@ export default class UtapiClient {
 
     /**
     * Updates counter for HeadObject action on an object in a Bucket resource.
-    * @param {string} reqUid - Request Unique Identifier
-    * @param {string} bucket - bucket name
-    * @param {callback} [cb] - (optional) callback to call
+    * @param {object} params - params for the metrics
+    * @param {object} params.bucket - bucket name
+    * @param {number} timestamp - normalized timestamp of current time
+    * @param {object} log - Werelogs request logger
+    * @param {callback} callback - callback to call
     * @return {undefined}
     */
-    pushMetricHeadObject(reqUid, bucket, cb) {
-        const callback = cb || this._noop;
-        if (this.disableClient) {
-            return callback();
-        }
-        const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
-        const timestamp = UtapiClient.getNormalizedTimestamp();
+    _pushMetricHeadObject(params, timestamp, log, callback) {
+        const { bucket } = params;
         log.trace('pushing metric', {
             method: 'UtapiClient.pushMetricHeadObject',
             bucket, timestamp,

--- a/tests/testUtils.js
+++ b/tests/testUtils.js
@@ -1,0 +1,5 @@
+export function getNormalizedTimestamp() {
+    const d = new Date();
+    const minutes = d.getMinutes();
+    return d.setMinutes((minutes - minutes % 15), 0, 0);
+}

--- a/tests/unit/testBuckets.js
+++ b/tests/unit/testBuckets.js
@@ -106,6 +106,9 @@ describe('Get Bucket Metrics', () => {
     it('should return metrics for outgoing bytes', done =>
         testOps('outgoingBytes', 'outgoingBytes', done));
 
+    it('should return metrics for create bucket', done =>
+        testOps('createBucket', 's3:CreateBucket', done));
+
     it('should return metrics for delete bucket', done =>
         testOps('deleteBucket', 's3:DeleteBucket', done));
 

--- a/tests/unit/testUtapiClient.js
+++ b/tests/unit/testUtapiClient.js
@@ -1,0 +1,132 @@
+import assert from 'assert';
+import { Logger } from 'werelogs';
+import Datastore from '../../src/lib/Datastore';
+import MemoryBackend from '../../src/lib/backend/Memory';
+import UtapiClient from '../../src/lib/UtapiClient';
+import { getNormalizedTimestamp } from '../testUtils';
+
+const memoryBackend = new MemoryBackend();
+const ds = new Datastore();
+ds.setClient(memoryBackend);
+const REQUID = 'aaaaaaaaaaaaaaaaaaa';
+const bucket = 'foo';
+const newByteLength = 1024;
+// const oldByteLength = 256;
+
+describe('UtapiClient:: enable/disable client', () => {
+    it('should disable client when no redis config is provided', () => {
+        const c = new UtapiClient();
+        assert.strictEqual(c instanceof UtapiClient, true);
+        assert.strictEqual(c.disableClient, true);
+        assert.strictEqual(c.log instanceof Logger, true);
+        assert.strictEqual(c.ds, null);
+    });
+
+    it('should enable client when redis config is provided', () => {
+        const c = new UtapiClient({ redis: { host: 'localhost', port: 6379 } });
+        assert.strictEqual(c instanceof UtapiClient, true);
+        assert.strictEqual(c.disableClient, false);
+        assert.strictEqual(c.log instanceof Logger, true);
+        assert.strictEqual(c.ds instanceof Datastore, true);
+    });
+});
+
+describe('UtapiClient:: push metrics', () => {
+    let c;
+    let timestamp;
+    beforeEach(() => {
+        c = new UtapiClient();
+        c.setDataStore(ds);
+        timestamp = getNormalizedTimestamp(Date.now());
+    });
+
+    afterEach(() => memoryBackend.flushDb());
+
+    it('should push metric for createBucket', done => {
+        c.pushMetric('createBucket', REQUID, { bucket }, () => {
+            const expected = {
+                's3:buckets:foo:storageUtilized:counter': '0',
+                's3:buckets:foo:numberOfObjects:counter': '0',
+                's3:buckets:foo:storageUtilized': [[timestamp, '0']],
+                's3:buckets:foo:numberOfObjects': [[timestamp, '0']],
+            };
+            expected[`s3:buckets:${timestamp}:foo:CreateBucket`] = '1';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
+    it('should push metric for deleteBucket', done => {
+        c.pushMetric('deleteBucket', REQUID, { bucket }, () => {
+            const expected = {};
+            expected[`s3:buckets:${timestamp}:foo:DeleteBucket`] = '1';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
+    it('should push metric for listBucket', done => {
+        c.pushMetric('listBucket', REQUID, { bucket }, () => {
+            const expected = {};
+            expected[`s3:buckets:${timestamp}:foo:ListBucket`] = '1';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
+    it('should push metric for getBucketAcl', done => {
+        c.pushMetric('getBucketAcl', REQUID, { bucket }, () => {
+            const expected = {};
+            expected[`s3:buckets:${timestamp}:foo:GetBucketAcl`] = '1';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
+    it('should push metric for putBucketAcl', done => {
+        c.pushMetric('putBucketAcl', REQUID, { bucket }, () => {
+            const expected = {};
+            expected[`s3:buckets:${timestamp}:foo:PutBucketAcl`] = '1';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
+    it('should push metric for uploadPart', done => {
+        c.pushMetric('uploadPart', REQUID, { bucket, newByteLength }, () => {
+            const expected = {
+                's3:buckets:foo:storageUtilized:counter': `${newByteLength}`,
+                's3:buckets:foo:storageUtilized': [[timestamp,
+                    `${newByteLength}`]],
+            };
+            expected[`s3:buckets:${timestamp}:foo:incomingBytes`] =
+                `${newByteLength}`;
+            expected[`s3:buckets:${timestamp}:foo:UploadPart`] = '1';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
+    it('should push metric for initiateMultipartUpload', done => {
+        c.pushMetric('initiateMultipartUpload', REQUID, { bucket }, () => {
+            const expected = {};
+            const k = `s3:buckets:${timestamp}:foo:InitiateMultipartUpload`;
+            expected[k] = '1';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
+    it('should push metric for completeMultipartUpload', done => {
+        c.pushMetric('completeMultipartUpload', REQUID, { bucket }, () => {
+            const expected = {
+                's3:buckets:foo:numberOfObjects:counter': '1',
+                's3:buckets:foo:numberOfObjects': [[timestamp, '1']],
+            };
+            const k = `s3:buckets:${timestamp}:foo:CompleteMultipartUpload`;
+            expected[k] = '1';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+});

--- a/tests/unit/testUtapiClient.js
+++ b/tests/unit/testUtapiClient.js
@@ -11,7 +11,17 @@ ds.setClient(memoryBackend);
 const REQUID = 'aaaaaaaaaaaaaaaaaaa';
 const bucket = 'foo';
 const newByteLength = 1024;
-// const oldByteLength = 256;
+
+// Set mock data of a particular size and count.
+function setData(objectSize, objectCount, timestamp) {
+    memoryBackend.data = {
+        's3:buckets:foo:storageUtilized:counter': objectSize,
+        's3:buckets:foo:numberOfObjects:counter': objectCount,
+        's3:buckets:foo:storageUtilized': [[timestamp, objectSize]],
+        's3:buckets:foo:numberOfObjects': [[timestamp, objectCount]],
+    };
+    return undefined;
+}
 
 describe('UtapiClient:: enable/disable client', () => {
     it('should disable client when no redis config is provided', () => {
@@ -92,6 +102,33 @@ describe('UtapiClient:: push metrics', () => {
         });
     });
 
+    it('should push metric for putBucketWebsite', done => {
+        c.pushMetric('putBucketWebsite', REQUID, { bucket }, () => {
+            const expected = {};
+            expected[`s3:buckets:${timestamp}:foo:PutBucketWebsite`] = '1';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
+    it('should push metric for getBucketWebsite', done => {
+        c.pushMetric('getBucketWebsite', REQUID, { bucket }, () => {
+            const expected = {};
+            expected[`s3:buckets:${timestamp}:foo:GetBucketWebsite`] = '1';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
+    it('should push metric for deleteBucketWebsite', done => {
+        c.pushMetric('deleteBucketWebsite', REQUID, { bucket }, () => {
+            const expected = {};
+            expected[`s3:buckets:${timestamp}:foo:DeleteBucketWebsite`] = '1';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
     it('should push metric for uploadPart', done => {
         c.pushMetric('uploadPart', REQUID, { bucket, newByteLength }, () => {
             const expected = {
@@ -125,6 +162,206 @@ describe('UtapiClient:: push metrics', () => {
             };
             const k = `s3:buckets:${timestamp}:foo:CompleteMultipartUpload`;
             expected[k] = '1';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
+    it('should push metric for listMultipartUploads', done => {
+        c.pushMetric('listMultipartUploads', REQUID, { bucket }, () => {
+            const expected = {};
+            const k = `s3:buckets:${timestamp}:foo:ListBucketMultipartUploads`;
+            expected[k] = '1';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
+    it('should push metric for listMultipartUploadParts', done => {
+        c.pushMetric('listMultipartUploadParts', REQUID, { bucket }, () => {
+            const expected = {};
+            const k = `s3:buckets:${timestamp}:foo:ListMultipartUploadParts`;
+            expected[k] = '1';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
+    it('should push metric for abortMultipartUpload', done => {
+        c.pushMetric('abortMultipartUpload', REQUID, { bucket }, () => {
+            const expected = {};
+            const k = `s3:buckets:${timestamp}:foo:AbortMultipartUpload`;
+            expected[k] = '1';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
+    it('should push metric for deleteObject', done => {
+        // Set mock data of one, 1024 byte object for `deleteObject` to update.
+        setData('1024', '1', timestamp);
+        c.pushMetric('deleteObject', REQUID, {
+            bucket,
+            byteLength: 1024,
+            numberOfObjects: 1,
+        }, () => {
+            const expected = {
+                's3:buckets:foo:storageUtilized:counter': '0',
+                's3:buckets:foo:numberOfObjects:counter': '0',
+                's3:buckets:foo:storageUtilized': [[timestamp, '0']],
+                's3:buckets:foo:numberOfObjects': [[timestamp, '0']],
+            };
+            const k = `s3:buckets:${timestamp}:foo:DeleteObject`;
+            expected[k] = '1';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
+    it('should push metric for multiObjectDelete', done => {
+        // Set mock data of two, 1024 byte objects for `multiObjectDelete` to
+        // update.
+        setData('2048', '2', timestamp);
+        c.pushMetric('multiObjectDelete', REQUID, {
+            bucket,
+            byteLength: 2048, // Total byte length of objects deleted.
+            numberOfObjects: 2,
+        }, () => {
+            const expected = {
+                's3:buckets:foo:storageUtilized:counter': '0',
+                's3:buckets:foo:numberOfObjects:counter': '0',
+                's3:buckets:foo:storageUtilized': [[timestamp, '0']],
+                's3:buckets:foo:numberOfObjects': [[timestamp, '0']],
+            };
+            const k = `s3:buckets:${timestamp}:foo:MultiObjectDelete`;
+            expected[k] = '1';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
+    it('should push metric for getObject', done => {
+        c.pushMetric('getObject', REQUID, {
+            bucket,
+            newByteLength: 1024,
+        }, () => {
+            const expected = {};
+            expected[`s3:buckets:${timestamp}:foo:outgoingBytes`] = '1024';
+            expected[`s3:buckets:${timestamp}:foo:GetObject`] = '1';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
+    it('should push metric for getObjectAcl', done => {
+        c.pushMetric('getObjectAcl', REQUID, { bucket }, () => {
+            const expected = {};
+            expected[`s3:buckets:${timestamp}:foo:GetObjectAcl`] = '1';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
+    it('should push metric for putObject', done => {
+        c.pushMetric('putObject', REQUID, {
+            bucket,
+            newByteLength: 1024,
+            oldByteLength: null,
+        }, () => {
+            const expected = {
+                's3:buckets:foo:storageUtilized:counter': '1024',
+                's3:buckets:foo:numberOfObjects:counter': '1',
+                's3:buckets:foo:storageUtilized': [[timestamp, '1024']],
+                's3:buckets:foo:numberOfObjects': [[timestamp, '1']],
+            };
+            expected[`s3:buckets:${timestamp}:foo:PutObject`] = '1';
+            expected[`s3:buckets:${timestamp}:foo:incomingBytes`] = '1024';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
+    it('should push metric for putObject overwrite', done => {
+        // Set mock data of one, 1024 byte object for `putObject` to overwrite.
+        setData('1024', '1', timestamp);
+        c.pushMetric('putObject', REQUID, {
+            bucket,
+            newByteLength: 2048,
+            oldByteLength: 1024,
+        }, () => {
+            const expected = {
+                's3:buckets:foo:storageUtilized:counter': '2048',
+                's3:buckets:foo:numberOfObjects:counter': '1',
+                's3:buckets:foo:storageUtilized': [[timestamp, '2048']],
+                's3:buckets:foo:numberOfObjects': [[timestamp, '1']],
+            };
+            expected[`s3:buckets:${timestamp}:foo:PutObject`] = '1';
+            expected[`s3:buckets:${timestamp}:foo:incomingBytes`] = '2048';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
+    it('should push metric for copyObject', done => {
+        c.pushMetric('copyObject', REQUID, {
+            bucket,
+            newByteLength: 1024,
+            oldByteLength: null,
+        }, () => {
+            const expected = {
+                's3:buckets:foo:storageUtilized:counter': '1024',
+                's3:buckets:foo:numberOfObjects:counter': '1',
+                's3:buckets:foo:storageUtilized': [[timestamp, '1024']],
+                's3:buckets:foo:numberOfObjects': [[timestamp, '1']],
+            };
+            expected[`s3:buckets:${timestamp}:foo:CopyObject`] = '1';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
+    it('should push metric for copyObject overwrite', done => {
+        // Set mock data of one, 1024 byte object for `copyObject` to overwrite.
+        setData('1024', '1', timestamp);
+        c.pushMetric('copyObject', REQUID, {
+            bucket,
+            newByteLength: 2048,
+            oldByteLength: 1024,
+        }, () => {
+            const expected = {
+                's3:buckets:foo:storageUtilized:counter': '2048',
+                's3:buckets:foo:numberOfObjects:counter': '1',
+                's3:buckets:foo:storageUtilized': [[timestamp, '2048']],
+                's3:buckets:foo:numberOfObjects': [[timestamp, '1']],
+            };
+            expected[`s3:buckets:${timestamp}:foo:CopyObject`] = '1';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
+    it('should push metric for putObjectAcl', done => {
+        c.pushMetric('putObjectAcl', REQUID, { bucket }, () => {
+            const expected = {};
+            expected[`s3:buckets:${timestamp}:foo:PutObjectAcl`] = '1';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
+    it('should push metric for headBucket', done => {
+        c.pushMetric('headBucket', REQUID, { bucket }, () => {
+            const expected = {};
+            expected[`s3:buckets:${timestamp}:foo:HeadBucket`] = '1';
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            done();
+        });
+    });
+
+    it('should push metric for headObject', done => {
+        c.pushMetric('headObject', REQUID, { bucket }, () => {
+            const expected = {};
+            expected[`s3:buckets:${timestamp}:foo:HeadObject`] = '1';
             assert.deepStrictEqual(memoryBackend.data, expected);
             done();
         });


### PR DESCRIPTION
This commit refactors all the older methods for pushing metrics to expose one
single method for pushing all metrics. This will help accommodating other
granularities (account, user, service) in the upcoming PRs.
