### PR TITLE
FT: Add account metrics to UtapiClient

### DIFF
--- a/tests/functional/testUtapiClient.js
+++ b/tests/functional/testUtapiClient.js
@@ -4,60 +4,90 @@ import UtapiClient from '../../src/lib/UtapiClient';
 import Datastore from '../../src/lib/Datastore';
 import redisClient from '../../src/utils/redisClient';
 import { Logger } from 'werelogs';
-import { getBucketCounters, getMetricFromKey } from '../../src/lib/schema';
-const bucket = 'foo';
+import { getCounters } from '../../src/lib/schema';
 const datastore = new Datastore();
 const utapiClient = new UtapiClient();
 const reqUid = 'foo';
 const redis = redisClient({ host: '127.0.0.1', port: 6379 }, Logger);
+const metricTypes = {
+    bucket: 'foo-bucket',
+    accountId: 'foo-account',
+};
+
+// Get the metric object for the given type
+function _getMetricObj(type) {
+    if (type === 'bucket') {
+        return { bucket: metricTypes[type] };
+    } else if (type === 'accountId') {
+        return { accountId: metricTypes[type] };
+    }
+    return undefined;
+}
+
+// Get the metric from the key that is passed
+function _getMetricFromKey(key, value, metricObj) {
+    let metric;
+    if ('bucket' in metricObj) {
+        metric = key.slice(22);
+    } else if ('accountId' in metricObj) {
+        metric = key.slice(24);
+    }
+    return metric.replace(`${value}:`).replace(':counter', '');
+}
+
 datastore.setClient(redis);
 utapiClient.setDataStore(datastore);
-function _assertCounters(bucket, cb) {
-    const counters = getBucketCounters(bucket);
+function _assertCounters(metricName, metricObj, cb) {
+    const counters = getCounters(metricObj);
     return mapSeries(counters, (item, next) =>
         datastore.get(item, (err, res) => {
             if (err) {
                 return next(err);
             }
-            const metric = getMetricFromKey(item, bucket)
-                .replace(':counter', '');
+            const metric = _getMetricFromKey(item, metricName, metricObj);
             assert.equal(res, 0, `${metric} must be 0`);
             return next();
         }), cb);
 }
 
-describe('Counters', () => {
-    afterEach(() => redis.flushdb());
+Object.keys(metricTypes).forEach(type => {
+    if (metricTypes[type] === undefined) {
+        return;
+    }
+    const metricObj = _getMetricObj(type);
+    describe(`Counters with ${type} metrics`, () => {
+        afterEach(() => redis.flushdb());
 
-    it('should set counters to 0 on bucket creation', done => {
-        utapiClient.pushMetric('createBucket', reqUid, { bucket },
-            () => _assertCounters(bucket, done));
-    });
+        it('should set counters to 0 on bucket creation', done => {
+            utapiClient.pushMetric('createBucket', reqUid, metricObj, () =>
+                _assertCounters(metricTypes[type], metricObj, done));
+        });
 
-    it('should reset counters on bucket re-creation', done => {
-        series([
-            next => utapiClient.pushMetric('createBucket', reqUid, { bucket },
-                next),
-            next => utapiClient.pushMetric('listBucket', reqUid, { bucket },
-                next),
-            next => utapiClient.pushMetric('putObject', reqUid, {
-                bucket,
-                newByteLength: 8,
-                oldByteLength: 0,
-            }, next),
-            next => utapiClient.pushMetric('getObject', reqUid, {
-                bucket,
-                newByteLength: 8,
-            }, next),
-            next => utapiClient.pushMetric('deleteObject', reqUid, {
-                bucket,
-                byteLength: 8,
-                numberOfObjects: 1,
-            }, next),
-            next => utapiClient.pushMetric('deleteBucket', reqUid, { bucket },
-                next),
-            next => utapiClient.pushMetric('createBucket', reqUid, { bucket },
-                next),
-        ], () => _assertCounters(bucket, done));
+        it('should reset counters on bucket re-creation', done => {
+            series([
+                next => utapiClient.pushMetric('createBucket', reqUid,
+                    metricObj, next),
+                next => utapiClient.pushMetric('listBucket', reqUid, metricObj,
+                    next),
+                next => utapiClient.pushMetric('putObject', reqUid,
+                    Object.assign(metricObj, {
+                        newByteLength: 8,
+                        oldByteLength: 0,
+                    }), next),
+                next => utapiClient.pushMetric('getObject', reqUid,
+                    Object.assign(metricObj, {
+                        newByteLength: 8,
+                    }), next),
+                next => utapiClient.pushMetric('deleteObject', reqUid,
+                    Object.assign(metricObj, {
+                        byteLength: 8,
+                        numberOfObjects: 1,
+                    }), next),
+                next => utapiClient.pushMetric('deleteBucket', reqUid,
+                    metricObj, next),
+                next => utapiClient.pushMetric('createBucket', reqUid,
+                    metricObj, next),
+            ], () => _assertCounters(metricTypes[type], metricObj, done));
+        });
     });
 });

--- a/tests/unit/testBuckets.js
+++ b/tests/unit/testBuckets.js
@@ -2,7 +2,7 @@ import assert from 'assert';
 import Buckets from '../../src/lib/Buckets';
 import MemoryBackend from '../../src/lib/backend/Memory';
 import Datastore from '../../src/lib/Datastore';
-import { genBucketStateKey, genBucketKey } from '../../src/lib/schema';
+import { generateStateKey, generateKey } from '../../src/lib/schema';
 import { Logger } from 'werelogs';
 const logger = new Logger('UtapiTest');
 const testBucket = 'foo';
@@ -64,23 +64,24 @@ function assertMetrics(bucket, props, done) {
 
 function testOps(keyIndex, metricindex, done) {
     const timestamp = new Date().setMinutes(0, 0, 0);
+    const metricObj = { bucket: `${testBucket}` };
     let key;
     let props = {};
     let val;
     if (keyIndex === 'storageUtilized' || keyIndex === 'numberOfObjects') {
-        key = genBucketStateKey(testBucket, keyIndex, timestamp);
+        key = generateStateKey(metricObj, keyIndex);
         val = 1024;
         props[metricindex] = [val, val];
         memBackend.zadd(key, timestamp, val, () =>
             assertMetrics(testBucket, props, done));
     } else if (keyIndex === 'incomingBytes' || keyIndex === 'outgoingBytes') {
-        key = genBucketKey(testBucket, keyIndex, timestamp);
+        key = generateKey(metricObj, keyIndex, timestamp);
         val = 1024;
         props[metricindex] = val;
         memBackend.incrby(key, val, () =>
             assertMetrics(testBucket, props, done));
     } else {
-        key = genBucketKey(testBucket, keyIndex, timestamp);
+        key = generateKey(metricObj, keyIndex, timestamp);
         val = 1;
         props = { operations: {} };
         props.operations[metricindex] = val;


### PR DESCRIPTION
Refactors the schema keys to accommodate additional metric granularities and updates `UtapiClient` to push account level metrics.