### PR TITLE
REFACTOR: Eliminate loops

### DIFF
--- a/src/lib/ListMetrics.js
+++ b/src/lib/ListMetrics.js
@@ -30,6 +30,7 @@ export default class ListMetrics {
         }
         const obj = {};
         obj[type] = resource;
+        obj.level = this.metric;
         return obj;
     }
 

--- a/src/lib/schema.js
+++ b/src/lib/schema.js
@@ -48,16 +48,10 @@ const keys = {
 * @return {string} - prefix for the schema key
 */
 function getSchemaPrefix(params, timestamp) {
-    // Map of possible metric types and their associated prefix level keys
-    const map = {
-        bucket: 'buckets',
-        accountId: 'accounts',
-    };
-    const metricType = Object.keys(params).find(k => k in map);
-    const level = map[metricType];
-    const id = params[metricType];
-    const prefix = timestamp === undefined ? `s3:${level}:${id}:` :
-        `s3:${level}:${timestamp}:${id}:`;
+    const { bucket, accountId, level } = params;
+    const id = bucket || accountId;
+    const prefix = timestamp ? `s3:${level}:${timestamp}:${id}:` :
+        `s3:${level}:${id}:`;
     return prefix;
 }
 

--- a/tests/functional/testUtapiClient.js
+++ b/tests/functional/testUtapiClient.js
@@ -16,12 +16,13 @@ const metricTypes = {
 
 // Get the metric object for the given type
 function _getMetricObj(type) {
-    if (type === 'bucket') {
-        return { bucket: metricTypes[type] };
-    } else if (type === 'accountId') {
-        return { accountId: metricTypes[type] };
-    }
-    return undefined;
+    const levels = {
+        bucket: 'buckets',
+        accountId: 'accounts',
+    };
+    const obj = { level: levels[type] };
+    obj[type] = metricTypes[type];
+    return obj;
 }
 
 // Get the metric from the key that is passed

--- a/tests/unit/testMetrics.js
+++ b/tests/unit/testMetrics.js
@@ -56,6 +56,7 @@ function assertMetrics(schemaKey, metricName, props, done) {
 function getSchemaObject(schemaKey) {
     const schemaObject = {};
     schemaObject[schemaKey] = resourceNames[schemaKey];
+    schemaObject.level = metricLevels[schemaKey];
     return schemaObject;
 }
 


### PR DESCRIPTION
Remove unnecessary loops in params array construction in UtapiClient by creating the object directly. This is possible because any irrelevant properties are already ignored in the pushMetric calls.

Also, remove two unnecessary `find` methods.