### PR TITLE
Ft/transactions

### DIFF
--- a/src/lib/Datastore.js
+++ b/src/lib/Datastore.js
@@ -123,7 +123,7 @@ export default class Datastore {
     * @return {undefined}
     */
     batch(cmds, cb) {
-        return this._client.pipeline(cmds).exec(cb);
+        return this._client.multi(cmds).exec(cb);
     }
 
     /**

--- a/src/lib/backend/Memory.js
+++ b/src/lib/backend/Memory.js
@@ -12,7 +12,7 @@ class Pipeline {
     * @param {Memory} db - Memory instance
     */
     constructor(cmds, db) {
-        this.cmds = cmds;
+        this.cmds = JSON.parse(JSON.stringify(cmds));
         this.db = db;
     }
 
@@ -306,7 +306,7 @@ export default class Memory {
     * @param {array} cmds - list of commands
     * @return {Pipeline} - Pipeline instance
     */
-    pipeline(cmds) {
+    multi(cmds) {
         return new Pipeline(cmds, this);
     }
 

--- a/tests/unit/testMemory.js
+++ b/tests/unit/testMemory.js
@@ -199,7 +199,7 @@ describe('Test Memory Backend', () => {
         const valStr = val.toString();
         const valIncr = (val + 1).toString();
         const expectedRes = [[null, valStr], [null, valIncr], [null, valIncr]];
-        mem.pipeline([
+        mem.multi([
             ['set', key, val],
             ['incr', key],
             ['get', key],


### PR DESCRIPTION
This PR includes the following commits

- **ft: use multi/exec instead of vanilla pipeline**

  This commit ensures that a batch of commands are isolated during execution.

- **ft: send all metrics to redis in the same transaction**

  This commit ensures that commands for all metric levels buckets, accounts,
users, service etc. are pushed in the same transaction. This guarantees
atomicity and saves on the round trips to the redis server.
