### PR TITLE
FIX: Send correct request object to Arsenal

### DIFF
--- a/src/lib/UtapiRequest.js
+++ b/src/lib/UtapiRequest.js
@@ -98,6 +98,18 @@ export default class UtapiRequest {
     }
 
     /**
+     * Set request pathname
+     *
+     * @param {string} pathname - pathname from url.parse
+     * of request.url (pathname minus query)
+     * @return {UtapiRequest} itself
+     */
+    setRequestPathname(pathname) {
+        this._requestPathname = pathname;
+        return this;
+    }
+
+    /**
      * Get http request object
      *
      * @return {object} Http request object
@@ -131,6 +143,15 @@ export default class UtapiRequest {
      */
     getRequestPath() {
         return this._requestPath;
+    }
+
+    /**
+     * Get request pathname
+     *
+     * @return {string} request pathname
+     */
+    getRequestPathname() {
+        return this._requestPathname;
     }
 
     /**

--- a/src/lib/server.js
+++ b/src/lib/server.js
@@ -67,7 +67,7 @@ class UtapiServer {
     requestListener(req, res, router) {
         // disable nagle algorithm
         req.socket.setNoDelay();
-        const { query, path } = url.parse(req.url, true);
+        const { query, path, pathname } = url.parse(req.url, true);
         const utapiRequest = new UtapiRequest()
             .setRequest(req)
             .setLog(this.logger.newRequestLogger())
@@ -79,6 +79,7 @@ class UtapiServer {
         }
         utapiRequest.setRequestQuery(query);
         utapiRequest.setRequestPath(path);
+        utapiRequest.setRequestPathname(pathname);
         // temp hack: healthcheck route
         if (path === '/_/healthcheck' && (req.method === 'GET'
             || req.method === 'POST')) {

--- a/src/router/Router.js
+++ b/src/router/Router.js
@@ -217,9 +217,10 @@ class Router {
             utapiRequest.getAction(), 'utapi')
         );
         auth.setHandler(this._vault);
-        const requestPlusPath = utapiRequest.getRequest();
-        requestPlusPath.path = utapiRequest.getRequestPath();
-        return auth.server.doAuth(requestPlusPath, log, (err, authResults) => {
+        const request = utapiRequest.getRequest();
+        request.path = utapiRequest.getRequestPathname();
+        request.query = utapiRequest.getRequestQuery();
+        return auth.server.doAuth(request, log, (err, authResults) => {
             if (err) {
                 return cb(err);
             }


### PR DESCRIPTION
* Adds a `query` property for passing to `doAuth`. 
* Uses `url.pathname` for the `path` property sent to Arsenal.