### PR TITLE
DEV: Allow pushing of unsupported metrics

### DIFF
--- a/src/lib/UtapiClient.js
+++ b/src/lib/UtapiClient.js
@@ -226,14 +226,18 @@ export default class UtapiClient {
     * @return {undefined}
     */
     pushMetric(metric, reqUid, params, cb) {
-        assert(methods[metric], `${metric} metric is not handled by Utapi`);
         const callback = cb || this._noop;
         if (this.disableClient) {
             return callback();
         }
         const log = this.log.newRequestLoggerFromSerializedUids(reqUid);
         const timestamp = UtapiClient.getNormalizedTimestamp();
-        return this[methods[metric]](params, timestamp, metric, log, callback);
+        if (this[methods[metric]]) {
+            return this[methods[metric]](params, timestamp, metric, log,
+                callback);
+        }
+        log.debug(`UtapiClient::pushMetric: ${metric} unsupported`);
+        return callback();
     }
 
     /**

--- a/tests/unit/testUtapiClient.js
+++ b/tests/unit/testUtapiClient.js
@@ -341,4 +341,10 @@ describe('UtapiClient:: push metrics', () => {
         const expected = getObject(timestamp, { action: 'HeadObject' });
         testMetric('headObject', metricTypes, expected, done);
     });
+
+    // Allows for decoupling of projects that use Utapi
+    it('should allow pushing an unsupported metric', done => {
+        const expected = {};
+        testMetric('unsupportedMetric', metricTypes, expected, done);
+    });
 });


### PR DESCRIPTION
Allow passing an unsupported metric to `UtapiClient` to enable merging branches in other repositories first. 

If an unsupported metric is passed in the call to `UtapiClient`, no metrics will be pushed to the Redis datastore.