### PR TITLE
FT: Add Utapi replay

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,4 +2,5 @@
 module.exports = {
     UtapiServer: require('./dist/lib/server.js').default,
     UtapiClient: require('./dist/lib/UtapiClient.js').default,
+    UtapiReplay: require('./dist/lib/UtapiReplay.js').default,
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.2.0",
     "babel-plugin-transform-es2015-parameters": "^6.2.0",
     "ioredis": "^2.3.0",
+    "node-schedule": "1.2.0",
     "vaultclient": "scality/vaultclient#rel/6.4",
     "werelogs": "scality/werelogs#rel/6.4"
   },

--- a/src/lib/Datastore.js
+++ b/src/lib/Datastore.js
@@ -127,6 +127,16 @@ export default class Datastore {
     }
 
     /**
+    * execute a pipeline of commands
+    * @param {string[]} cmds - list of commands
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    pipeline(cmds, cb) {
+        return this._client.pipeline(cmds).exec(cb);
+    }
+
+    /**
     * remove elements from the sorted set that fall between the min and max
     * scores
     * @param {string} key - key holding the value
@@ -137,5 +147,48 @@ export default class Datastore {
     */
     zremrangebyscore(key, min, max, cb) {
         return this._client.zremrangebyscore(key, min, max, cb);
+    }
+
+    /**
+    * push a value to the head of the list
+    * @param {string} key - key for the list
+    * @param {string} val - value to be pushed onto the list
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    lpush(key, val, cb) {
+        return this._client.lpush(key, val, cb);
+    }
+
+    /**
+    * remove and return the last element of the list
+    * @param {string} key - key for the list
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    rpop(key, cb) {
+        return this._client.rpop(key, cb);
+    }
+
+    /**
+    * get a range of elements from the list
+    * @param {string} key - key for the list
+    * @param {number} start - start offset in a zero-based index
+    * @param {number} stop - stop offset in a zero-based index
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    lrange(key, start, stop, cb) {
+        return this._client.lrange(key, start, stop, cb);
+    }
+
+    /**
+    * get the length of the list
+    * @param {string} key - key for the list
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    llen(key, cb) {
+        return this._client.llen(key, cb);
     }
 }

--- a/src/lib/UtapiReplay.js
+++ b/src/lib/UtapiReplay.js
@@ -1,0 +1,203 @@
+import assert from 'assert';
+import async from 'async';
+import { scheduleJob } from 'node-schedule';
+import UtapiClient from './UtapiClient';
+import Datastore from './Datastore';
+import redisClient from '../utils/redisClient';
+import safeJsonParse from '../utils/safeJsonParse';
+import { Logger } from 'werelogs';
+
+// Every five minutes. Cron-style scheduling used by node-schedule.
+const REPLAY_SCHEDULE = '*/5 * * * *';
+const BATCH_SIZE = 10;
+
+export default class UtapiReplay {
+    /**
+     * Create a UtapiReplay
+     * @param {object} [config] - The configuration of UtapiReplay
+     * @param {object} [config.log] - Object defining the level and dumplevel of
+     * the log
+     * @param {object} [config.redis] - Object defining the host and port of the
+     * Redis datastore
+     * @param {object} [config.localCache] - Object defining the host and port
+     * of the local cache datastore
+     * @param {number} [config.batchSize] - The batch size to get metrics from
+     * Redis datastore
+     * @param {string} [config.replaySchedule] - The Cron-style schedule at
+     * which the replay job should run
+     */
+    constructor(config) {
+        this.log = new Logger('UtapiReplay', {
+            level: 'info',
+            dump: 'error',
+        });
+        this.replaySchedule = REPLAY_SCHEDULE;
+        this.batchSize = BATCH_SIZE;
+        this.replayLock = false;
+        this.disableReplay = true;
+
+        if (config) {
+            if (config.log) {
+                this.log = new Logger('UtapiReplay', {
+                    level: config.log.level,
+                    dump: config.log.dumpLevel,
+                });
+            }
+            const message = 'missing required property in UtapiReplay ' +
+                'configuration';
+            assert(config.redis, `${message}: redis`);
+            assert(config.localCache, `${message}: localCache`);
+            this.utapiClient = new UtapiClient(config);
+            this.localCache = new Datastore()
+                .setClient(redisClient(config.localCache, this.log));
+            if (config.replaySchedule) {
+                this.replaySchedule = config.replaySchedule;
+            }
+            if (config.batchSize) {
+                this.batchSize = config.batchSize;
+            }
+            this.disableReplay = false;
+        }
+    }
+
+    /**
+     * Sets the replay lock.
+     * @param {boolean} isLocked - The value to set `this.replayLock`.
+     * @param {callback} cb - Callback to call.
+     * @return {UtapiReplay} this - UtapiReplay instance.
+     */
+    _setReplayLock(isLocked) {
+        this.replayLock = isLocked;
+        return this;
+    }
+
+    /**
+     * Validates that all required items can be retrived from the JSON object.
+     * @param {string} data - JSON of list element from local cache.
+     * @return {boolean} Returns `true` if object is valid, `false` otherwise.
+     */
+    _validateElement(data) {
+        const { action, reqUid, params, timestamp } = data;
+        if (!action || !reqUid || !params || !timestamp) {
+            this.log.fatal('missing required parameter in element',
+                { method: 'UtapiReplay._validateElement' });
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Pushes list elements using the array returned by nodeio.
+     * @param {array[]} metricsArr - The array returned by nodeio containing the
+     * an array of an error code and value for each element in the cache list.
+     * @param {callback} cb - Callback to call.
+     * @return {function} async.each - Iterates through all array elements.
+     */
+    _pushCachedMetrics(metricsArr, cb) {
+        return async.each(metricsArr, (arr, next) => {
+            const actionErr = arr[0];
+            const element = arr[1];
+            // If there is an error in one of the RPOP commands, it remains in
+            // the local cache list, so do not handle that element.
+            if (!actionErr && element) {
+                const { error, result } = safeJsonParse(element);
+                if (error) {
+                    this.log.error('cannot parse element into JSON',
+                        { method: 'UtapiReplay._pushCachedMetrics' });
+                    return next(error);
+                }
+                if (!this._validateElement(result)) {
+                    return next();
+                }
+                this.log.trace('pushing metric with utapiClient::pushMetric',
+                    { method: 'UtapiReplay._pushCachedMetrics' });
+                const { action, reqUid, params } = result;
+                // We do not pass the callback to pushMetric since UtapiClient
+                // will handle pushing it to local cache if internal error.
+                this.utapiClient.pushMetric(action, reqUid, params);
+            }
+            return next();
+        }, err => cb(err));
+    }
+
+    /**
+     * Gets and removes all elements from the local cache list.
+     * @param {number} listLen - The length of the local cache list.
+     * @return {function} async.timesSeries - Iterates through all list
+     * elements.
+     */
+    _getCachedMetrics(listLen) {
+        const count = Math.ceil(listLen / this.batchSize);
+        return async.timesSeries(count, (n, next) => {
+            // We create the array each time because ioredis modifies it.
+            const cmds = [];
+            for (let i = 0; i < this.batchSize; i++) {
+                cmds.push(['rpop', 's3:utapireplay']);
+            }
+            return this.localCache.pipeline(cmds, (err, res) => {
+                if (err) {
+                    return next(err);
+                }
+                return this._pushCachedMetrics(res, next);
+            });
+        }, err => {
+            if (err) {
+                this.log.error('cannot push element from cache list', {
+                    method: 'UtapiReplay._getCachedMetrics',
+                    error: err,
+                });
+                this.log.info(`replay job completed: ${err}`);
+                return this._setReplayLock(false);
+            }
+            this.log.info(`replay job completed: pushed ${listLen} metrics`);
+            return this._setReplayLock(false);
+        });
+    }
+
+    /**
+     * Checks local cache to determine if any action has been logged.
+     * @return {function} this.localCache.llen - Gets the length of the list
+     * in local cache.
+     */
+    _checkLocalCache() {
+        return this.localCache.llen('s3:utapireplay', (err, res) => {
+            if (err) {
+                this.log.error('cannot get length of localCache list', {
+                    method: 'UtapiReplay._getCachedMetrics',
+                    error: err.stack || err,
+                });
+                return this._setReplayLock(false);
+            }
+            if (res > 0) {
+                return this._getCachedMetrics(res);
+            }
+            this.log.info('replay job completed: no cached metrics found');
+            return this._setReplayLock(false);
+        });
+    }
+
+    /**
+     * Starts the replay job at the given job schedule.
+     * @return {UtapiReplay} this - UtapiReplay instance.
+     */
+    start() {
+        if (this.disableReplay) {
+            this.log.info('disabled utapi replay scheduler');
+            return this;
+        }
+        const replay = scheduleJob(this.replaySchedule, () => {
+            // Ensure no elements are still being pushed by a prior replay.
+            if (!this.replayLock) {
+                this._setReplayLock(true);
+                return this._checkLocalCache();
+            }
+            return undefined;
+        });
+        replay.on('scheduled', date =>
+            this.log.info(`replay job started: ${date}`));
+        this.log.info('enabled utapi replay scheduler', {
+            schedule: this.replaySchedule,
+        });
+        return this;
+    }
+}

--- a/tests/functional/testReplay.js
+++ b/tests/functional/testReplay.js
@@ -1,0 +1,237 @@
+import assert from 'assert';
+import async from 'async';
+import { Logger } from 'werelogs';
+import UtapiReplay from '../../src/lib/UtapiReplay';
+import UtapiClient from '../../src/lib/UtapiClient';
+import Datastore from '../../src/lib/Datastore';
+import redisClient from '../../src/utils/redisClient';
+import { getAllResourceTypeKeys } from '../testUtils';
+import safeJsonParse from '../../src/utils/safeJsonParse';
+const localCache = redisClient({
+    host: '127.0.0.1',
+    port: 6379,
+}, Logger);
+const datastore = new Datastore().setClient(localCache);
+const utapiClient = new UtapiClient({
+    redis: {
+        host: '127.0.0.1',
+        port: 4242, // Set the datastore client to a port it cannot connect on.
+    },
+    localCache: {
+        host: '127.0.0.1',
+        port: 6379, // Set the local cache a port for successful connection.
+    },
+});
+const log = new Logger();
+const objSize = 1024;
+// All actions supported by Utapi.
+const actions = [
+    'createBucket',
+    'deleteBucket',
+    'listBucket',
+    'getBucketAcl',
+    'putBucketAcl',
+    'putBucketCors',
+    'getBucketCors',
+    'deleteBucketCors',
+    'putBucketWebsite',
+    'getBucketWebsite',
+    'deleteBucketWebsite',
+    'uploadPart',
+    'initiateMultipartUpload',
+    'completeMultipartUpload',
+    'listMultipartUploads',
+    'listMultipartUploadParts',
+    'abortMultipartUpload',
+    'deleteObject',
+    'multiObjectDelete',
+    'getObject',
+    'getObjectAcl',
+    'putObject',
+    'copyObject',
+    'putObjectAcl',
+    'headBucket',
+    'headObject',
+];
+
+// Get the proper params object for a pushMetric call for the given action.
+function getParams(action) {
+    const resources = {
+        bucket: 'foo-bucket',
+        accountId: 'foo-account',
+    };
+    switch (action) {
+    case 'getObject':
+        return Object.assign(resources, {
+            newByteLength: objSize,
+        });
+    case 'uploadPart':
+    case 'putObject':
+    case 'copyObject':
+        return Object.assign(resources, {
+            newByteLength: objSize,
+            oldByteLength: null,
+        });
+    case 'deleteObject':
+        return Object.assign(resources, {
+            byteLength: objSize,
+            numberOfObjects: 1,
+        });
+    case 'multiObjectDelete':
+        return Object.assign(resources, {
+            byteLength: objSize * 2,
+            numberOfObjects: 2,
+        });
+    default:
+        return resources;
+    }
+}
+
+// Check that a list element has the correct data to make a pushMetric call.
+function checkListElement(action, params, res) {
+    const { error, result } = safeJsonParse(res);
+    assert(!error, 'cannot parse cached element into JSON');
+    const { reqUid, timestamp } = result;
+    const currTimestamp = UtapiClient.getNormalizedTimestamp();
+    const fifteenMinutes = 900000; // Milliseconds.
+    // Allow for previous timestamp interval, since we cannot know start time.
+    assert(timestamp, currTimestamp || currTimestamp - fifteenMinutes,
+        'incorrect timestamp value');
+    assert(reqUid !== undefined,
+        `reqUid property not in cached element: ${action}`);
+    const reqLog = log.newRequestLoggerFromSerializedUids(reqUid);
+    const reqUids = reqLog.getSerializedUids();
+    // The first two reqUidss should be those in the response.
+    const expectedReqUid = reqUids.substring(0, reqUids.lastIndexOf(':'));
+    // We want the action and original params for use during the replay.
+    assert.deepStrictEqual(result, {
+        action,
+        reqUid: expectedReqUid,
+        params,
+        timestamp,
+    }, `incorrect value for action: ${action}`);
+}
+
+// Check the length of the local cache list.
+function checkListLength(expectedLength, cb) {
+    return datastore.llen('s3:utapireplay', (err, res) => {
+        if (err) {
+            return cb(err);
+        }
+        assert.strictEqual(res, expectedLength,
+            `expected list length to be ${expectedLength}`);
+        return cb();
+    });
+}
+
+// Push each metric to the local cache list.
+function pushAllMetrics(cb) {
+    return async.eachSeries(actions, (action, next) => {
+        const reqLog = log.newRequestLogger();
+        const reqUid = reqLog.getSerializedUids();
+        const params = getParams(action);
+        return utapiClient.pushMetric(action, reqUid, params, err => {
+            // We want a simulated internal error.
+            if (err && !err.InternalError) {
+                return next(err);
+            }
+            return datastore.lrange('s3:utapireplay', 0, 0, (err, res) => {
+                if (err) {
+                    return next(err);
+                }
+                checkListElement(action, params, res);
+                return next();
+            });
+        });
+    }, err => {
+        if (err) {
+            return cb(err);
+        }
+        return checkListLength(actions.length, cb);
+    });
+}
+
+// Pop each metric from the local cache list.
+function popAllMetrics(cb) {
+    return async.eachSeries(actions, (action, next) => {
+        datastore.rpop('s3:utapireplay', (err, res) => {
+            if (err) {
+                return next(err);
+            }
+            checkListElement(action, getParams(action), res);
+            return next();
+        });
+    }, err => {
+        if (err) {
+            return cb(err);
+        }
+        return checkListLength(0, cb);
+    });
+}
+
+// Checks that all schema keys are stored with the correct values.
+function checkAllMetrics(cb) {
+    const keys = getAllResourceTypeKeys();
+    return async.each(keys, (key, next) =>
+        datastore.get(key, (err, res) => {
+            if (err) {
+                return next(err);
+            }
+            let expected = 1; // Actions should have been incremented once.
+            if (key.includes('incomingBytes')) {
+                expected = objSize * 2; // putObject and uploadPart.
+            } else if (key.includes('outgoingBytes')) {
+                expected = objSize; // getObject.
+            } else if (key.includes('storageUtilized') ||
+                key.includes('numberOfObjects')) {
+                expected = 0; // After PUT and DELETE operations, should be 0.
+            }
+            assert.strictEqual(parseInt(res, 10), expected, 'incorrect value ' +
+                `of key: ${key}`);
+            return next();
+        }), err => cb(err));
+}
+
+describe('Replay', () => {
+    describe('Local cache list', () => {
+        after(() => localCache.flushdb());
+
+        it('should push all metrics to the local cache list', done =>
+            pushAllMetrics(done));
+
+        it('should pop all metrics from the local cache list', done =>
+            popAllMetrics(done));
+    });
+
+    describe('UtapiReplay', () => {
+        // Set redis to correct port so replay successfully pushes metrics.
+        const replay = new UtapiReplay({
+            redis: { host: '127.0.0.1', port: 6379 },
+            replaySchedule: '*/1 * * * * *', // Run replay every second.
+            localCache: {
+                host: '127.0.0.1',
+                port: 6379,
+            },
+        });
+        replay.start();
+
+        after(() => localCache.flushdb());
+
+        it('should record all metrics from the local cache as schema keys',
+            function callback(done) {
+                this.timeout(5000);
+                return pushAllMetrics(err => {
+                    if (err) {
+                        return done(err);
+                    }
+                    // Give time to ensure list elements are pushed by replay.
+                    return setTimeout(() => checkAllMetrics(err => {
+                        if (err) {
+                            return done(err);
+                        }
+                        return checkListLength(0, done);
+                    }), 3000);
+                });
+            });
+    });
+});

--- a/tests/functional/testUtapiClient.js
+++ b/tests/functional/testUtapiClient.js
@@ -5,10 +5,22 @@ import Datastore from '../../src/lib/Datastore';
 import redisClient from '../../src/utils/redisClient';
 import { Logger } from 'werelogs';
 import { getCounters } from '../../src/lib/schema';
-const datastore = new Datastore();
-const utapiClient = new UtapiClient();
+const redis = redisClient({
+    host: '127.0.0.1',
+    port: 6379,
+}, Logger);
+const datastore = new Datastore().setClient(redis);
+const utapiClient = new UtapiClient({
+    redis: {
+        host: '127.0.0.1',
+        port: 6379,
+    },
+    localCache: {
+        host: '127.0.0.1',
+        port: 6379,
+    },
+});
 const reqUid = 'foo';
-const redis = redisClient({ host: '127.0.0.1', port: 6379 }, Logger);
 const metricTypes = {
     bucket: 'foo-bucket',
     accountId: 'foo-account',
@@ -36,8 +48,6 @@ function _getMetricFromKey(key, value, metricObj) {
     return metric.replace(`${value}:`).replace(':counter', '');
 }
 
-datastore.setClient(redis);
-utapiClient.setDataStore(datastore);
 function _assertCounters(metricName, metricObj, cb) {
     const counters = getCounters(metricObj);
     return mapSeries(counters, (item, next) =>

--- a/tests/testUtils.js
+++ b/tests/testUtils.js
@@ -1,5 +1,37 @@
+import { getKeys, getCounters } from '../src/lib/schema';
+
+const resouceTypes = ['buckets', 'accounts'];
+const propertyNames = {
+    buckets: 'bucket',
+    accounts: 'accountId',
+};
+const resources = {
+    buckets: 'foo-bucket',
+    accounts: 'foo-account',
+};
+
 export function getNormalizedTimestamp() {
     const d = new Date();
     const minutes = d.getMinutes();
     return d.setMinutes((minutes - minutes % 15), 0, 0);
+}
+
+// Build the resouceType object that gets keys from the schema.
+function _getResourceTypeObject(resourceType) {
+    const obj = { level: resourceType };
+    obj[propertyNames[resourceType]] = resources[resourceType];
+    return obj;
+}
+
+// Get all keys for each resource type from the schema.
+export function getAllResourceTypeKeys() {
+    const timestamp = getNormalizedTimestamp(Date.now());
+    const allResourceTypeKeys = resouceTypes.map(resourceType => {
+        const obj = _getResourceTypeObject(resourceType);
+        const counters = getCounters(obj);
+        const keys = getKeys(obj, timestamp);
+        return counters.concat(keys);
+    });
+    // Concatenate each array of resourceType keys into one single array.
+    return [].concat.apply([], allResourceTypeKeys);
 }

--- a/tests/unit/testUtapiClient.js
+++ b/tests/unit/testUtapiClient.js
@@ -13,6 +13,11 @@ const metricTypes = {
     bucket: 'foo-bucket',
     accountId: 'foo-account',
 };
+const redisLocal = { host: 'localhost', port: 6379 };
+const config = {
+    redis: redisLocal,
+    localCache: redisLocal,
+};
 
 // Get prefix values to construct the expected Redis schema keys
 function getPrefixValues(timestamp) {
@@ -83,7 +88,7 @@ function getObject(timestamp, data) {
 }
 
 function testMetric(metric, params, expected, cb) {
-    const c = new UtapiClient();
+    const c = new UtapiClient(config);
     c.setDataStore(ds);
     c.pushMetric(metric, REQUID, params, () => {
         assert.deepStrictEqual(memoryBackend.data, expected);
@@ -97,11 +102,11 @@ describe('UtapiClient:: enable/disable client', () => {
         assert.strictEqual(c instanceof UtapiClient, true);
         assert.strictEqual(c.disableClient, true);
         assert.strictEqual(c.log instanceof Logger, true);
-        assert.strictEqual(c.ds, null);
+        assert.strictEqual(c.ds, undefined);
     });
 
     it('should enable client when redis config is provided', () => {
-        const c = new UtapiClient({ redis: { host: 'localhost', port: 6379 } });
+        const c = new UtapiClient(config);
         assert.strictEqual(c instanceof UtapiClient, true);
         assert.strictEqual(c.disableClient, false);
         assert.strictEqual(c.log instanceof Logger, true);


### PR DESCRIPTION
Update `UtapiClient` to push metrics to a local cache (Redis List datatype) if an internal error occurs (for example, in a case where we are unable to connect to the Redis server).

Add a class `UtapiReplay` that attempts to push any cached metrics with `UtapiClient` at the given interval or schedule.

Depends on https://github.com/scality/S3/pull/612