### PR TITLE
FIX: Update storageUtilized on abortMPU

### DIFF
--- a/tests/functional/testReplay.js
+++ b/tests/functional/testReplay.js
@@ -72,6 +72,10 @@ function getParams(action) {
             newByteLength: objSize,
             oldByteLength: null,
         });
+    case 'abortMultipartUpload':
+        return Object.assign(resources, {
+            byteLength: objSize,
+        });
     case 'deleteObject':
         return Object.assign(resources, {
             byteLength: objSize,
@@ -79,7 +83,7 @@ function getParams(action) {
         });
     case 'multiObjectDelete':
         return Object.assign(resources, {
-            byteLength: objSize * 2,
+            byteLength: objSize,
             numberOfObjects: 2,
         });
     default:

--- a/tests/unit/testUtapiClient.js
+++ b/tests/unit/testUtapiClient.js
@@ -241,9 +241,16 @@ describe('UtapiClient:: push metrics', () => {
     });
 
     it('should push abortMultipartUpload metrics', done => {
-        const expected = getObject(timestamp,
-            { action: 'AbortMultipartUpload' });
-        testMetric('abortMultipartUpload', metricTypes, expected, done);
+        const expected = getObject(timestamp, {
+            action: 'AbortMultipartUpload',
+            storageUtilized: '0',
+        });
+        Object.assign(params, metricTypes, { byteLength: 1024 });
+        // Set mock data of one, 1024 byte part object for
+        // `AbortMultipartUpload` to update.
+        const data = { storageUtilized: '1024' };
+        setMockData(data, timestamp, () =>
+            testMetric('abortMultipartUpload', params, expected, done));
     });
 
     it('should push deleteObject metrics', done => {


### PR DESCRIPTION
Require a `byteLength` property with an abortMPU operation to enable correct updating of the `storageUtilized` value.

Fix https://github.com/scality/utapi/issues/39.