### PR TITLE
ft: support out of order operations

### DIFF
--- a/tests/unit/testUtapiClient.js
+++ b/tests/unit/testUtapiClient.js
@@ -125,11 +125,7 @@ describe('UtapiClient:: push metrics', () => {
     afterEach(() => memoryBackend.flushDb());
 
     it('should push createBucket metrics', done => {
-        const expected = getObject(timestamp, {
-            action: 'CreateBucket',
-            storageUtilized: '0',
-            numberOfObjects: '0',
-        });
+        const expected = getObject(timestamp, { action: 'CreateBucket' });
         testMetric('createBucket', metricTypes, expected, done);
     });
 


### PR DESCRIPTION
Former logic was setting counters to 0 on bucket creation which would
affect counters when push metric requests come in out of order,
for example, delete object AA -> put object AA -> create bucket A. This would
happen if Redis Sentinel is down, the metrics are cached temporarily and replayed
later.