### PR TITLE
fix: remove hiredis module

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,5 @@
     "start": "node index.js",
     "test": "mocha --compilers js:babel-core/register --recursive tests/unit"
   },
-  "private": true,
-  "optionalDependencies": {
-    "hiredis": "^0.5.0"
-  }
+  "private": true
 }

--- a/src/utils/redisClient.js
+++ b/src/utils/redisClient.js
@@ -1,14 +1,5 @@
 import Redis from 'ioredis';
 
-function _moduleCheck() {
-    try {
-        require.resolve('hiredis');
-    } catch (e) {
-        return false;
-    }
-    return true;
-}
-
 /**
 * Creates a new Redis client instance
 * @param {object} config - redis configuration
@@ -21,10 +12,6 @@ export default function redisClient(config, log) {
         enableOfflineQueue: false,
         // keep alive 3 seconds
         keepAlive: 3000,
-        // dropBufferSupport option performs better with
-        // hiredis (native redis module) and not with the default
-        // javascript redis parser
-        dropBufferSupport: _moduleCheck(),
     }, config));
     redisClient.on('error', err => log.trace('error with redis client', {
         error: err,


### PR DESCRIPTION
This module was intended for faster parsing of heavy responses from Redis.
In our use case, the default parser is fast enough and ioredis is ditching this
module in favor of the default parser in the next version.