### PR TITLE
chore: remove babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ push metrics directly to the underlying datastore (Redis) without the need of an
 extra HTTP request to Utapi.
 
 ```js
-import { UtapiClient } from 'utapi';
+const { UtapiClient } = require('utapi');
 
 const config = {
     redis: {

--- a/handlers/metricsHandlers.js
+++ b/handlers/metricsHandlers.js
@@ -1,4 +1,4 @@
-import ListMetrics from '../lib/ListMetrics';
+const ListMetrics = require('../lib/ListMetrics');
 
 function listRecentMetrics(utapiRequest, metric, service, cb) {
     const log = utapiRequest.getLog();
@@ -14,7 +14,7 @@ function listRecentMetrics(utapiRequest, metric, service, cb) {
  * Handles Buckets resource actions
  */
 
-export class BucketsHandler {
+class BucketsHandler {
     /**
     * List metrics for the given list of buckets
     * @param {UtapiRequest} utapiRequest - UtapiRequest instance
@@ -49,7 +49,7 @@ export class BucketsHandler {
  * Handles Accounts resource actions
  */
 
-export class AccountsHandler {
+class AccountsHandler {
     /**
     * List metrics for the given list of accounts
     * @param {UtapiRequest} utapiRequest - UtapiRequest instance
@@ -84,7 +84,7 @@ export class AccountsHandler {
  * Handles Services resource actions
  */
 
-export class ServiceHandler {
+class ServiceHandler {
     /**
     * List metrics for the given list of services
     * @param {UtapiRequest} utapiRequest - UtapiRequest instance
@@ -119,7 +119,7 @@ export class ServiceHandler {
  * Handles Users resource actions
  */
 
-export class UsersHandler {
+class UsersHandler {
     /**
     * List metrics for the given list of users
     * @param {UtapiRequest} utapiRequest - UtapiRequest instance
@@ -148,3 +148,10 @@ export class UsersHandler {
         return listRecentMetrics(utapiRequest, 'users', service, cb);
     }
 }
+
+module.exports = {
+    BucketsHandler,
+    AccountsHandler,
+    ServiceHandler,
+    UsersHandler,
+};

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'; // eslint-disable-line strict
 module.exports = {
-    UtapiServer: require('./dist/lib/server.js').default,
-    UtapiClient: require('./dist/lib/UtapiClient.js').default,
-    UtapiReplay: require('./dist/lib/UtapiReplay.js').default,
+    UtapiServer: require('./lib/server.js'),
+    UtapiClient: require('./lib/UtapiClient.js'),
+    UtapiReplay: require('./lib/UtapiReplay.js'),
 };

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1,6 +1,6 @@
-import assert from 'assert';
-import fs from 'fs';
-import path from 'path';
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
 
 /**
  * Reads from a config file and returns the content as a config object
@@ -12,7 +12,7 @@ class Config {
          * It can be overridden using the UTAPI_CONFIG_FILE environment var.
          */
         this._basePath = path.resolve(__dirname, '..');
-        this.path = `${this._basePath}/../config.json`;
+        this.path = `${this._basePath}/config.json`;
         if (process.env.UTAPI_CONFIG_FILE !== undefined) {
             this.path = process.env.UTAPI_CONFIG_FILE;
         }
@@ -164,4 +164,4 @@ class Config {
     }
 }
 
-export default new Config();
+module.exports = new Config();

--- a/lib/Datastore.js
+++ b/lib/Datastore.js
@@ -1,5 +1,5 @@
 /* Provides methods for operations on a datastore */
-export default class Datastore {
+class Datastore {
     /**
     * @constructor
     */
@@ -226,3 +226,5 @@ export default class Datastore {
         return this._client.llen(key, cb);
     }
 }
+
+module.exports = Datastore;

--- a/lib/ListMetrics.js
+++ b/lib/ListMetrics.js
@@ -1,14 +1,14 @@
-import async from 'async';
-import { errors } from 'arsenal';
-import { getMetricFromKey, getKeys, generateStateKey } from './schema';
-import s3metricResponseJSON from '../../models/s3metricResponse';
-import config from './Config';
-import Vault from './Vault';
+const async = require('async');
+const { errors } = require('arsenal');
+const { getMetricFromKey, getKeys, generateStateKey } = require('./schema');
+const s3metricResponseJSON = require('../models/s3metricResponse');
+const config = require('./Config');
+const Vault = require('./Vault');
 
 /**
 * Provides methods to get metrics of different levels
 */
-export default class ListMetrics {
+class ListMetrics {
 
     /**
      * Assign the metric property to an instance of this class
@@ -269,3 +269,5 @@ export default class ListMetrics {
         });
     }
 }
+
+module.exports = ListMetrics;

--- a/lib/UtapiClient.js
+++ b/lib/UtapiClient.js
@@ -1,10 +1,9 @@
-import assert from 'assert';
-import { Logger } from 'werelogs';
-import Datastore from './Datastore';
-import { generateKey, generateCounter, generateStateKey }
-    from './schema';
-import { errors } from 'arsenal';
-import redisClient from '../utils/redisClient';
+const assert = require('assert');
+const { Logger } = require('werelogs');
+const Datastore = require('./Datastore');
+const { generateKey, generateCounter, generateStateKey } = require('./schema');
+const { errors } = require('arsenal');
+const redisClient = require('../utils/redisClient');
 
 const methods = {
     createBucket: '_genericPushMetric',
@@ -48,7 +47,7 @@ const metricObj = {
     users: 'userId',
 };
 
-export default class UtapiClient {
+class UtapiClient {
     /**
      * Create a UtapiClient
      * @param {object} [config] - The configuration of UtapiClient
@@ -856,3 +855,5 @@ export default class UtapiClient {
         });
     }
 }
+
+module.exports = UtapiClient;

--- a/lib/UtapiReplay.js
+++ b/lib/UtapiReplay.js
@@ -1,11 +1,11 @@
-import assert from 'assert';
-import async from 'async';
-import { scheduleJob } from 'node-schedule';
-import UtapiClient from './UtapiClient';
-import Datastore from './Datastore';
-import redisClient from '../utils/redisClient';
-import safeJsonParse from '../utils/safeJsonParse';
-import { Logger } from 'werelogs';
+const assert = require('assert');
+const async = require('async');
+const { scheduleJob } = require('node-schedule');
+const UtapiClient = require('./UtapiClient');
+const Datastore = require('./Datastore');
+const redisClient = require('../utils/redisClient');
+const safeJsonParse = require('../utils/safeJsonParse');
+const { Logger } = require('werelogs');
 
 // Every five minutes. Cron-style scheduling used by node-schedule.
 const REPLAY_SCHEDULE = '*/5 * * * *';
@@ -13,7 +13,7 @@ const REPLAY_SCHEDULE = '*/5 * * * *';
 const TTL = 60 * 15;
 const BATCH_SIZE = 10;
 
-export default class UtapiReplay {
+class UtapiReplay {
     /**
      * Create a UtapiReplay
      * @param {object} [config] - The configuration of UtapiReplay
@@ -209,3 +209,5 @@ export default class UtapiReplay {
         return this;
     }
 }
+
+module.exports = UtapiReplay;

--- a/lib/UtapiRequest.js
+++ b/lib/UtapiRequest.js
@@ -3,7 +3,7 @@
  *
  * @class
  */
-export default class UtapiRequest {
+class UtapiRequest {
 
     constructor() {
         this._log = null;
@@ -269,3 +269,5 @@ export default class UtapiRequest {
     }
 
 }
+
+module.exports = UtapiRequest;

--- a/lib/Vault.js
+++ b/lib/Vault.js
@@ -1,4 +1,4 @@
-import vaultclient from 'vaultclient';
+const vaultclient = require('vaultclient');
 
 /**
 @class Vault
@@ -77,4 +77,4 @@ class Vault {
 
 }
 
-export default Vault;
+module.exports = Vault;

--- a/lib/backend/Memory.js
+++ b/lib/backend/Memory.js
@@ -1,5 +1,5 @@
-import assert from 'assert';
-import map from 'async/map';
+const assert = require('assert');
+const map = require('async/map');
 
 /**
 * Pipeline - executes multiple commands sent as a batch
@@ -47,7 +47,7 @@ class Pipeline {
 /**
 * Memory backend which emulates IoRedis client methods
 */
-export default class Memory {
+class Memory {
     constructor() {
         this.data = {};
     }
@@ -323,3 +323,5 @@ export default class Memory {
         return this.data;
     }
 }
+
+module.exports = Memory;

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -69,7 +69,7 @@ function getSchemaPrefix(params, timestamp) {
 * @param {number} timestamp - unix timestamp normalized to the nearest 15 min.
 * @return {string} - schema key
 */
-export function generateKey(params, metric, timestamp) {
+function generateKey(params, metric, timestamp) {
     const prefix = getSchemaPrefix(params, timestamp);
     return keys[metric](prefix);
 }
@@ -79,7 +79,7 @@ export function generateKey(params, metric, timestamp) {
 * @param {object} params - object with metric type and id as a property
 * @return {string[]} - array of keys for counters
 */
-export function getCounters(params) {
+function getCounters(params) {
     const prefix = getSchemaPrefix(params);
     return Object.keys(counters).map(item => counters[item](prefix));
 }
@@ -90,7 +90,7 @@ export function getCounters(params) {
 * @param {number} timestamp - unix timestamp normalized to the nearest 15 min.
 * @return {string[]} - list of keys
 */
-export function getKeys(params, timestamp) {
+function getKeys(params, timestamp) {
     const prefix = getSchemaPrefix(params, timestamp);
     return Object.keys(keys).map(item => keys[item](prefix));
 }
@@ -100,7 +100,7 @@ export function getKeys(params, timestamp) {
 * @param {string} key - schema key
 * @return {string} metric - Utapi metric
 */
-export function getMetricFromKey(key) {
+function getMetricFromKey(key) {
     const fields = key.split(':');
     // Identify the location of the metric in the array.
     const metricLocation = key.includes('counter') ? -2 : -1;
@@ -112,7 +112,7 @@ export function getMetricFromKey(key) {
 * @param {object} params - object with metric type and id as a property
 * @return {string[]} - list of keys
 */
-export function getStateKeys(params) {
+function getStateKeys(params) {
     const prefix = getSchemaPrefix(params);
     return Object.keys(stateKeys).map(item => stateKeys[item](prefix));
 }
@@ -123,7 +123,7 @@ export function getStateKeys(params) {
 * @param {string} metric - metric to generate a key for
 * @return {string} - schema key
 */
-export function generateStateKey(params, metric) {
+function generateStateKey(params, metric) {
     const prefix = getSchemaPrefix(params);
     return stateKeys[metric](prefix);
 }
@@ -134,7 +134,17 @@ export function generateStateKey(params, metric) {
 * @param {string} metric - metric to generate a key for
 * @return {string} - schema key
 */
-export function generateCounter(params, metric) {
+function generateCounter(params, metric) {
     const prefix = getSchemaPrefix(params);
     return counters[metric](prefix);
 }
+
+module.exports = {
+    getCounters,
+    getKeys,
+    getMetricFromKey,
+    getStateKeys,
+    generateCounter,
+    generateKey,
+    generateStateKey,
+};

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,17 +1,18 @@
-import http from 'http';
-import https from 'https';
-import url from 'url';
+const http = require('http');
+const https = require('https');
+const url = require('url');
 
-import { Clustering, https as arsenalHttps, errors, ipCheck } from 'arsenal';
-import { Logger } from 'werelogs';
+const { Clustering, errors, ipCheck } = require('arsenal');
+const arsenalHttps = require('arsenal').https;
+const { Logger } = require('werelogs');
 
-import config from './Config';
-import routes from '../router/routes';
-import Route from '../router/Route';
-import Router from '../router/Router';
-import UtapiRequest from '../lib/UtapiRequest';
-import Datastore from './Datastore';
-import redisClient from '../utils/redisClient';
+const config = require('./Config');
+const routes = require('../router/routes');
+const Route = require('../router/Route');
+const Router = require('../router/Router');
+const UtapiRequest = require('../lib/UtapiRequest');
+const Datastore = require('./Datastore');
+const redisClient = require('../utils/redisClient');
 
 class UtapiServer {
     /**
@@ -211,7 +212,7 @@ class UtapiServer {
 * @property {object} params.log - logger configuration
 * @return {undefined}
 */
-export default function spawn(params) {
+function spawn(params) {
     Object.assign(config, params);
     const { workers, redis, log, port } = config;
 
@@ -224,3 +225,5 @@ export default function spawn(params) {
         server.startup();
     });
 }
+
+module.exports = spawn;

--- a/package.json
+++ b/package.json
@@ -19,11 +19,6 @@
   "dependencies": {
     "arsenal": "scality/Arsenal",
     "async": "^2.0.1",
-    "babel-cli": "6.14.0",
-    "babel-core": "^6.2.1",
-    "babel-plugin-transform-es2015-destructuring": "^6.1.18",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.2.0",
-    "babel-plugin-transform-es2015-parameters": "^6.2.0",
     "ioredis": "^2.3.0",
     "node-schedule": "1.2.0",
     "vaultclient": "scality/vaultclient",
@@ -37,12 +32,11 @@
     "mocha": "^3.0.2"
   },
   "scripts": {
-    "postinstall": "babel --ignore node_modules src/ --out-dir dist",
-    "ft_test": "mocha --compilers js:babel-core/register --recursive tests/functional",
+    "ft_test": "mocha --recursive tests/functional",
     "lint": "eslint $(git ls-files '*.js')",
     "lint_md": "mdlint $(git ls-files '*.md')",
     "start": "node index.js",
-    "test": "mocha --compilers js:babel-core/register --recursive tests/unit"
+    "test": "mocha --recursive tests/unit"
   },
   "private": true
 }

--- a/responses/listMetrics.js
+++ b/responses/listMetrics.js
@@ -1,0 +1,5 @@
+function listMetrics(utapiRequest, data, cb) {
+    return cb(null, data);
+}
+
+module.exports = listMetrics;

--- a/router/Route.js
+++ b/router/Route.js
@@ -1,7 +1,7 @@
 /**
  * This class is used to retain information about a route
  */
-export default class Route {
+class Route {
 
     /**
      * Constructor
@@ -78,3 +78,5 @@ export default class Route {
         return this._properties.resource;
     }
 }
+
+module.exports = Route;

--- a/router/Router.js
+++ b/router/Router.js
@@ -1,8 +1,8 @@
-import assert from 'assert';
-import url from 'url';
-import { auth, errors, policies } from 'arsenal';
-import safeJsonParse from '../utils/safeJsonParse';
-import Vault from '../lib/Vault';
+const assert = require('assert');
+const url = require('url');
+const { auth, errors, policies } = require('arsenal');
+const safeJsonParse = require('../utils/safeJsonParse');
+const Vault = require('../lib/Vault');
 
 class Router {
 

--- a/router/routes.js
+++ b/router/routes.js
@@ -1,13 +1,13 @@
-import { BucketsHandler, AccountsHandler, UsersHandler, ServiceHandler } from
-    '../handlers/metricsHandlers';
-import { validateBucketsListMetrics, validateAccountsListMetrics,
+const { BucketsHandler, AccountsHandler, UsersHandler, ServiceHandler } =
+    require('../handlers/metricsHandlers');
+const { validateBucketsListMetrics, validateAccountsListMetrics,
     validateUsersListMetrics, validateServiceListMetrics,
     validateBucketsListRecentMetrics, validateAccountsListRecentMetrics,
-    validateUsersListRecentMetrics, validateServiceListRecentMetrics } from
-    '../validators/listMetrics';
-import listMetricsResponse from '../responses/listMetrics';
+    validateUsersListRecentMetrics, validateServiceListRecentMetrics } =
+    require('../validators/listMetrics');
+const listMetricsResponse = require('../responses/listMetrics');
 
-export default [
+module.exports = [
     {
         validator: validateBucketsListMetrics,
         handler: BucketsHandler.listMetrics,

--- a/src/responses/listMetrics.js
+++ b/src/responses/listMetrics.js
@@ -1,3 +1,0 @@
-export default function listMetrics(utapiRequest, data, cb) {
-    return cb(null, data);
-}

--- a/tests/functional/testReplay.js
+++ b/tests/functional/testReplay.js
@@ -1,12 +1,12 @@
-import assert from 'assert';
-import async from 'async';
-import { Logger } from 'werelogs';
-import UtapiReplay from '../../src/lib/UtapiReplay';
-import UtapiClient from '../../src/lib/UtapiClient';
-import Datastore from '../../src/lib/Datastore';
-import redisClient from '../../src/utils/redisClient';
-import { getAllResourceTypeKeys } from '../testUtils';
-import safeJsonParse from '../../src/utils/safeJsonParse';
+const assert = require('assert');
+const async = require('async');
+const { Logger } = require('werelogs');
+const UtapiReplay = require('../../lib/UtapiReplay');
+const UtapiClient = require('../../lib/UtapiClient');
+const Datastore = require('../../lib/Datastore');
+const redisClient = require('../../utils/redisClient');
+const { getAllResourceTypeKeys } = require('../testUtils');
+const safeJsonParse = require('../../utils/safeJsonParse');
 const localCache = redisClient({
     host: '127.0.0.1',
     port: 6379,

--- a/tests/functional/testUtapiClient.js
+++ b/tests/functional/testUtapiClient.js
@@ -1,11 +1,11 @@
-import assert from 'assert';
-import { map, series } from 'async';
-import UtapiClient from '../../src/lib/UtapiClient';
-import Datastore from '../../src/lib/Datastore';
-import redisClient from '../../src/utils/redisClient';
-import { Logger } from 'werelogs';
-import { getCounters, getMetricFromKey,
-    getStateKeys } from '../../src/lib/schema';
+const assert = require('assert');
+const { map, series } = require('async');
+const UtapiClient = require('../../lib/UtapiClient');
+const Datastore = require('../../lib/Datastore');
+const redisClient = require('../../utils/redisClient');
+const { Logger } = require('werelogs');
+const { getCounters, getMetricFromKey,
+    getStateKeys } = require('../../lib/schema');
 const redis = redisClient({
     host: '127.0.0.1',
     port: 6379,

--- a/tests/testUtils.js
+++ b/tests/testUtils.js
@@ -1,4 +1,4 @@
-import { getKeys, getCounters } from '../src/lib/schema';
+const { getKeys, getCounters } = require('../lib/schema');
 
 const resouceTypes = ['buckets', 'accounts', 'service'];
 const propertyNames = {
@@ -10,7 +10,7 @@ const resources = {
     accounts: 'foo-account',
 };
 
-export function getNormalizedTimestamp() {
+function getNormalizedTimestamp() {
     const d = new Date();
     const minutes = d.getMinutes();
     return d.setMinutes((minutes - minutes % 15), 0, 0);
@@ -26,7 +26,7 @@ function _getResourceTypeObject(resourceType) {
 }
 
 // Get all keys for each resource type from the schema.
-export function getAllResourceTypeKeys() {
+function getAllResourceTypeKeys() {
     const timestamp = getNormalizedTimestamp(Date.now());
     const allResourceTypeKeys = resouceTypes.map(resourceType => {
         const obj = _getResourceTypeObject(resourceType);
@@ -37,3 +37,8 @@ export function getAllResourceTypeKeys() {
     // Concatenate each array of resourceType keys into one single array.
     return [].concat.apply([], allResourceTypeKeys);
 }
+
+module.exports = {
+    getAllResourceTypeKeys,
+    getNormalizedTimestamp,
+};

--- a/tests/unit/testMemory.js
+++ b/tests/unit/testMemory.js
@@ -1,5 +1,5 @@
-import assert from 'assert';
-import MemoryBackend from '../../src/lib/backend/Memory';
+const assert = require('assert');
+const MemoryBackend = require('../../lib/backend/Memory');
 
 
 describe('Test Memory Backend', () => {

--- a/tests/unit/testMetrics.js
+++ b/tests/unit/testMetrics.js
@@ -1,10 +1,10 @@
-import assert from 'assert';
-import MemoryBackend from '../../src/lib/backend/Memory';
-import Datastore from '../../src/lib/Datastore';
-import ListMetrics from '../../src/lib/ListMetrics';
-import { generateStateKey, generateKey } from '../../src/lib/schema';
-import { Logger } from 'werelogs';
-import s3metricResponseJSON from '../../models/s3metricResponse';
+const assert = require('assert');
+const MemoryBackend = require('../../lib/backend/Memory');
+const Datastore = require('../../lib/Datastore');
+const ListMetrics = require('../../lib/ListMetrics');
+const { generateStateKey, generateKey } = require('../../lib/schema');
+const { Logger } = require('werelogs');
+const s3metricResponseJSON = require('../../models/s3metricResponse');
 const logger = new Logger('UtapiTest');
 const memBackend = new MemoryBackend();
 const datastore = new Datastore();

--- a/tests/unit/testUtapiClient.js
+++ b/tests/unit/testUtapiClient.js
@@ -1,9 +1,9 @@
-import assert from 'assert';
-import { Logger } from 'werelogs';
-import Datastore from '../../src/lib/Datastore';
-import MemoryBackend from '../../src/lib/backend/Memory';
-import UtapiClient from '../../src/lib/UtapiClient';
-import { getNormalizedTimestamp } from '../testUtils';
+const assert = require('assert');
+const { Logger } = require('werelogs');
+const Datastore = require('../../lib/Datastore');
+const MemoryBackend = require('../../lib/backend/Memory');
+const UtapiClient = require('../../lib/UtapiClient');
+const { getNormalizedTimestamp } = require('../testUtils');
 
 const memoryBackend = new MemoryBackend();
 const ds = new Datastore();

--- a/utils/redisClient.js
+++ b/utils/redisClient.js
@@ -1,4 +1,4 @@
-import Redis from 'ioredis';
+const Redis = require('ioredis');
 
 /**
 * Creates a new Redis client instance
@@ -6,7 +6,7 @@ import Redis from 'ioredis';
 * @param {Werelogs} log - Werelogs logger
 * @return {Redis} - Redis client instance
 */
-export default function redisClient(config, log) {
+function redisClient(config, log) {
     const redisClient = new Redis(Object.assign({
         // disable offline queue
         enableOfflineQueue: false,
@@ -18,3 +18,5 @@ export default function redisClient(config, log) {
     }));
     return redisClient;
 }
+
+module.exports = redisClient;

--- a/utils/safeJsonParse.js
+++ b/utils/safeJsonParse.js
@@ -9,7 +9,7 @@
 * @param {string} jsonStr - stringified json
 * @return {Response} - response object
 */
-export default function safeJsonParse(jsonStr) {
+function safeJsonParse(jsonStr) {
     let result = null;
     try {
         result = JSON.parse(jsonStr);
@@ -18,3 +18,5 @@ export default function safeJsonParse(jsonStr) {
     }
     return { error: null, result };
 }
+
+module.exports = safeJsonParse;

--- a/validators/Validator.js
+++ b/validators/Validator.js
@@ -1,6 +1,6 @@
-import { errors } from 'arsenal';
-import validateMetric from './validateMetric';
-import validateTimeRange from './validateTimeRange';
+const { errors } = require('arsenal');
+const validateMetric = require('./validateMetric');
+const validateTimeRange = require('./validateTimeRange');
 
 const _keys = Symbol();
 const _dict = Symbol();
@@ -39,7 +39,7 @@ const keyError = new Map([
  *
  * @class Validator
  */
-export default class Validator {
+class Validator {
 
     /**
      * Constructor
@@ -139,3 +139,5 @@ export default class Validator {
     }
 
 }
+
+module.exports = Validator;

--- a/validators/listMetrics.js
+++ b/validators/listMetrics.js
@@ -1,4 +1,4 @@
-import Validator from './Validator';
+const Validator = require('./Validator');
 
 /**
  * Get the validator for a particular metric type
@@ -22,7 +22,7 @@ function getValidator(metricType, dict, isRecentListing) {
  * @param {object} dict - Input fields for route
  * @return {function} the return value of `getValidator`
  */
-export function validateBucketsListMetrics(dict) {
+function validateBucketsListMetrics(dict) {
     return getValidator('buckets', dict);
 }
 
@@ -32,7 +32,7 @@ export function validateBucketsListMetrics(dict) {
  * @param {object} dict - Input fields for route
  * @return {function} the return value of `getValidator`
  */
-export function validateBucketsListRecentMetrics(dict) {
+function validateBucketsListRecentMetrics(dict) {
     return getValidator('buckets', dict, true);
 }
 
@@ -41,7 +41,7 @@ export function validateBucketsListRecentMetrics(dict) {
  * @param {object} dict - Input fields for route
  * @return {function} the return value of `getValidator`
  */
-export function validateAccountsListMetrics(dict) {
+function validateAccountsListMetrics(dict) {
     return getValidator('accounts', dict);
 }
 
@@ -51,7 +51,7 @@ export function validateAccountsListMetrics(dict) {
  * @param {object} dict - Input fields for route
  * @return {function} the return value of `getValidator`
  */
-export function validateAccountsListRecentMetrics(dict) {
+function validateAccountsListRecentMetrics(dict) {
     return getValidator('accounts', dict, true);
 }
 
@@ -60,7 +60,7 @@ export function validateAccountsListRecentMetrics(dict) {
  * @param {object} dict - Input fields for route
  * @return {function} the return value of `getValidator`
  */
-export function validateUsersListMetrics(dict) {
+function validateUsersListMetrics(dict) {
     return getValidator('users', dict);
 }
 
@@ -70,7 +70,7 @@ export function validateUsersListMetrics(dict) {
  * @param {object} dict - Input fields for route
  * @return {function} the return value of `getValidator`
  */
-export function validateUsersListRecentMetrics(dict) {
+function validateUsersListRecentMetrics(dict) {
     return getValidator('users', dict, true);
 }
 
@@ -79,7 +79,7 @@ export function validateUsersListRecentMetrics(dict) {
  * @param {object} dict - Input fields for route
  * @return {function} the return value of `getValidator`
  */
-export function validateServiceListMetrics(dict) {
+function validateServiceListMetrics(dict) {
     return getValidator('service', dict);
 }
 
@@ -89,6 +89,17 @@ export function validateServiceListMetrics(dict) {
  * @param {object} dict - Input fields for route
  * @return {function} the return value of `getValidator`
  */
-export function validateServiceListRecentMetrics(dict) {
+function validateServiceListRecentMetrics(dict) {
     return getValidator('service', dict, true);
 }
+
+module.exports = {
+    validateBucketsListMetrics,
+    validateBucketsListRecentMetrics,
+    validateAccountsListMetrics,
+    validateAccountsListRecentMetrics,
+    validateUsersListMetrics,
+    validateUsersListRecentMetrics,
+    validateServiceListMetrics,
+    validateServiceListRecentMetrics,
+};

--- a/validators/validateMetric.js
+++ b/validators/validateMetric.js
@@ -3,7 +3,9 @@
 * @param {string[]} metricType - array of metric names
 * @return {boolean} - validation result
 */
-export default function validateMetric(metricType) {
+function validateMetric(metricType) {
     return Array.isArray(metricType) && metricType.length > 0
         && metricType.every(item => typeof item === 'string');
 }
+
+module.exports = validateMetric;

--- a/validators/validateTimeRange.js
+++ b/validators/validateTimeRange.js
@@ -3,7 +3,7 @@
 * @param {number[]} timeRange - array of bucket names
 * @return {boolean} - validation result
 */
-export default function validateTimeRange(timeRange) {
+function validateTimeRange(timeRange) {
     if (Array.isArray(timeRange) && timeRange.length > 0 && timeRange.length < 3
         && timeRange.every(item => typeof item === 'number')) {
         // check for start time
@@ -45,3 +45,5 @@ export default function validateTimeRange(timeRange) {
     }
     return false;
 }
+
+module.exports = validateTimeRange;


### PR DESCRIPTION
- Change ES6 imports to require
- Remove post-install step which compiles the code using babel
- Remove babel modules
- Remove src, dist directories as we no longer compile
