### PR TITLE
chore: change package from private to public

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,5 @@
     "lint_md": "mdlint $(git ls-files '*.md')",
     "start": "node index.js",
     "test": "mocha --recursive tests/unit"
-  },
-  "private": true
+  }
 }


### PR DESCRIPTION
We no monger need to specify `private: true` since this repo is public.