### PR TITLE
FT: Allow no auth for request

### DIFF
--- a/lib/Vault.js
+++ b/lib/Vault.js
@@ -42,6 +42,9 @@ class Vault {
      * @return {undefined}
     */
     authenticateV4Request(params, requestContexts, callback) {
+        if (process.env.NO_AUTH) {
+            return callback(null, undefined);
+        }
         const { accessKey, signatureFromRequest, region, scopeDate,
             stringToSign }
             = params.data;


### PR DESCRIPTION
For open source usage or testing purposes, we can allow getting metrics without Vault.