### PR TITLE
Chore: eslint modules upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "werelogs": "scality/werelogs"
   },
   "devDependencies": {
-    "eslint": "^2.4.0",
-    "eslint-plugin-react": "^4.3.0",
-    "eslint-config-airbnb": "^6.0.0",
-    "eslint-config-scality": "scality/Guidelines",
+    "eslint": "4.6.0",
+    "eslint-config-airbnb-base": "12.0.0",
+    "eslint-config-scality": "scality/Guidelines#chore/upgradeEslint",
+    "eslint-plugin-import": "2.7.0",
     "mocha": "^3.0.2"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "eslint": "4.6.0",
     "eslint-config-airbnb-base": "12.0.0",
-    "eslint-config-scality": "scality/Guidelines#chore/upgradeEslint",
+    "eslint-config-scality": "scality/Guidelines",
     "eslint-plugin-import": "2.7.0",
     "mocha": "^3.0.2"
   },


### PR DESCRIPTION
Eslint upgrade will be in 2 steps:
- First add lint changes, drop package version changes and make sure new linter changes are compatible with the old eslint versions.
- Second, add this PR that has the version upgrades and merge after confirming first PR changes convert nicely

This should be merged after https://github.com/scality/utapi/pull/153