### PR TITLE
Add eve ci support

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -1,0 +1,39 @@
+---
+version: 0.2
+
+branches:
+  default:
+    stage: pre-merge
+
+stages:
+  pre-merge:
+    worker:
+      type: docker
+      path: eve/workers/unit_and_feature_tests
+      volumes:
+        - '/home/eve/workspace'
+    steps:
+      - Git:
+          name: fetch source
+          repourl: '%(prop:git_reference)s'
+          shallow: True
+          retryFetch: True
+          haltOnFailure: True
+      - ShellCommand:
+          name: npm install
+          command: npm install
+#      - ShellCommand:
+#          name: get api node modules from cache
+#          command: mv /home/eve/node_reqs/node_modules .
+      - ShellCommand:
+          name: run static analysis tools on markdown
+          command: npm run lint_md
+      - ShellCommand:
+          name: run static analysis tools on code
+          command: npm run lint
+      - ShellCommand:
+          name: run unit tests
+          command: npm test
+      - ShellCommand:
+          name: run feature tests
+          command: npm run ft_test

--- a/eve/workers/unit_and_feature_tests/Dockerfile
+++ b/eve/workers/unit_and_feature_tests/Dockerfile
@@ -1,0 +1,26 @@
+FROM buildpack-deps:jessie-curl
+
+#
+# Install apt packages needed by backbeat and buildbot_worker
+#
+ENV LANG C.UTF-8
+COPY utapi_packages.list buildbot_worker_packages.list /tmp/
+
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
+    && apt-get update -qq \
+    && cat /tmp/*packages.list | xargs apt-get install -y \
+    && pip install pip==9.0.1 \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -f /tmp/*packages.list \
+    && rm -f /etc/supervisor/conf.d/*.conf
+
+
+#
+# Run buildbot-worker on startup through supervisor
+#
+ARG BUILDBOT_VERSION
+
+RUN pip install buildbot-worker==$BUILDBOT_VERSION
+ADD supervisor/buildbot_worker.conf /etc/supervisor/conf.d/
+
+CMD ["supervisord", "-n"]

--- a/eve/workers/unit_and_feature_tests/buildbot_worker_packages.list
+++ b/eve/workers/unit_and_feature_tests/buildbot_worker_packages.list
@@ -1,0 +1,9 @@
+ca-certificates
+git
+libffi-dev
+libssl-dev
+python2.7
+python2.7-dev
+python-pip
+sudo
+supervisor

--- a/eve/workers/unit_and_feature_tests/supervisor/buildbot_worker.conf
+++ b/eve/workers/unit_and_feature_tests/supervisor/buildbot_worker.conf
@@ -1,0 +1,9 @@
+[program:buildbot_worker]
+command=/bin/sh -c 'buildbot-worker create-worker . "%(ENV_BUILDMASTER)s:%(ENV_BUILDMASTER_PORT)s" "%(ENV_WORKERNAME)s" "%(ENV_WORKERPASS)s"  && buildbot-worker start --nodaemon'
+autostart=true
+autorestart=false
+
+[program:redis]
+command=/usr/bin/redis-server
+autostart=true
+autorestart=false

--- a/eve/workers/unit_and_feature_tests/utapi_packages.list
+++ b/eve/workers/unit_and_feature_tests/utapi_packages.list
@@ -1,0 +1,3 @@
+build-essential
+redis-server
+nodejs


### PR DESCRIPTION
This adds support for EVE.

There's a YAML file that describes the steps and a Dockerfile that defines the worker setup.

**Important:** 
packages.json has been moved to eve's docker context. This will cache the dependency installation and improve builds speed. The original path now contain a symlink. We need to check that this does not break anything.
