### PR TITLE
rf: detect overwrite & bytes del for complete mpu

### DIFF
--- a/lib/UtapiClient.js
+++ b/lib/UtapiClient.js
@@ -252,7 +252,7 @@ class UtapiClient {
         this._checkMetricTypes(params);
         const props = [];
         const { byteLength, newByteLength, oldByteLength, numberOfObjects,
-            bytesDeleted, overwriting } = params;
+            overwriting } = params;
         // We add a `service` property to any non-service level to be able to
         // build the appropriate schema key.
         this.metrics.forEach(level => {
@@ -263,7 +263,6 @@ class UtapiClient {
                     level,
                     service: this.service,
                     byteLength,
-                    bytesDeleted,
                     newByteLength,
                     oldByteLength,
                     numberOfObjects,
@@ -501,7 +500,7 @@ class UtapiClient {
     * @param {string} [params.accountId] - (optional) account ID
     * @param {boolean} params.overwriting - whether the action is overwriting
     * previous object data
-    * @param {number} params.bytesDeleted - number of bytes deleted by
+    * @param {number} params.byteLength - number of bytes deleted by
     * overwriting data or cleaning up extra parts
     * @param {number} timestamp - normalized timestamp of current time
     * @param {string} action - action metric to update
@@ -511,10 +510,10 @@ class UtapiClient {
     */
     _pushMetricCompleteMultipartUpload(params, timestamp, action, log,
         callback) {
-        this._checkProperties(params, ['bytesDeleted', 'overwriting']);
+        this._checkProperties(params, ['byteLength', 'overwriting']);
         this._logMetric(params, '_pushMetricCompleteMultipartUpload', timestamp,
             log);
-        const { bytesDeleted, overwriting } = params;
+        const { byteLength, overwriting } = params;
         // if not overwriting data, increment the number of objects
         const redisCmd = overwriting === true ? 'get' : 'incr';
         const paramsArr = this._getParamsArr(params);
@@ -522,7 +521,7 @@ class UtapiClient {
         paramsArr.forEach(p => {
             cmds.push(
                 ['decrby', generateCounter(p, 'storageUtilizedCounter'),
-                    bytesDeleted],
+                    byteLength],
                 [redisCmd, generateCounter(p, 'numberOfObjectsCounter')],
                 ['incr', generateKey(p, action, timestamp)]
             );

--- a/lib/UtapiClient.js
+++ b/lib/UtapiClient.js
@@ -176,7 +176,7 @@ class UtapiClient {
     * (for object overwrites). This value can be `null` for a new object,
     * or >= 0 for an existing object with content-length 0 or greater than 0.
     * @param {number} [params.numberOfObjects] - (optional) number of obects
-    * @param {boolean} [params.overwriting] - (optional) whether the action
+    * @param {boolean} [params.isOverwrite] - (optional) whether the action
     * is overwriting data - specific to complete multipart upload
     * @param {array} properties - (option) properties to assert types for
     * @return {undefined}
@@ -185,9 +185,9 @@ class UtapiClient {
         properties.forEach(prop => {
             assert(params[prop] !== undefined, 'Metric object must include ' +
                 `${prop} property`);
-            if (prop === 'overwriting') {
+            if (prop === 'isOverwrite') {
                 assert(typeof params[prop] === 'boolean',
-                    'overwriting property must be a boolean');
+                    'isOverwrite property must be a boolean');
             } else if (prop === 'oldByteLength') {
                 assert(typeof params[prop] === 'number' ||
                     params[prop] === null, 'oldByteLength  property must be ' +
@@ -252,7 +252,7 @@ class UtapiClient {
         this._checkMetricTypes(params);
         const props = [];
         const { byteLength, newByteLength, oldByteLength, numberOfObjects,
-            overwriting } = params;
+            isOverwrite } = params;
         // We add a `service` property to any non-service level to be able to
         // build the appropriate schema key.
         this.metrics.forEach(level => {
@@ -266,7 +266,7 @@ class UtapiClient {
                     newByteLength,
                     oldByteLength,
                     numberOfObjects,
-                    overwriting,
+                    isOverwrite,
                 };
                 if (level !== 'service') {
                     obj[prop] = params[prop];
@@ -498,7 +498,7 @@ class UtapiClient {
     * @param {object} params - params for the metrics
     * @param {string} [params.bucket] - (optional) bucket name
     * @param {string} [params.accountId] - (optional) account ID
-    * @param {boolean} params.overwriting - whether the action is overwriting
+    * @param {boolean} params.isOverwrite - whether the action is overwriting
     * previous object data
     * @param {number} params.byteLength - number of bytes deleted by
     * overwriting data or cleaning up extra parts
@@ -510,12 +510,12 @@ class UtapiClient {
     */
     _pushMetricCompleteMultipartUpload(params, timestamp, action, log,
         callback) {
-        this._checkProperties(params, ['byteLength', 'overwriting']);
+        this._checkProperties(params, ['byteLength', 'isOverwrite']);
         this._logMetric(params, '_pushMetricCompleteMultipartUpload', timestamp,
             log);
-        const { byteLength, overwriting } = params;
+        const { byteLength, isOverwrite } = params;
         // if not overwriting data, increment the number of objects
-        const redisCmd = overwriting === true ? 'get' : 'incr';
+        const redisCmd = isOverwrite === true ? 'get' : 'incr';
         const paramsArr = this._getParamsArr(params);
         const cmds = [];
         paramsArr.forEach(p => {

--- a/lib/UtapiClient.js
+++ b/lib/UtapiClient.js
@@ -176,6 +176,8 @@ class UtapiClient {
     * (for object overwrites). This value can be `null` for a new object,
     * or >= 0 for an existing object with content-length 0 or greater than 0.
     * @param {number} [params.numberOfObjects] - (optional) number of obects
+    * @param {boolean} [params.overwriting] - (optional) whether the action
+    * is overwriting data - specific to complete multipart upload
     * @param {array} properties - (option) properties to assert types for
     * @return {undefined}
     */
@@ -183,7 +185,10 @@ class UtapiClient {
         properties.forEach(prop => {
             assert(params[prop] !== undefined, 'Metric object must include ' +
                 `${prop} property`);
-            if (prop === 'oldByteLength') {
+            if (prop === 'overwriting') {
+                assert(typeof params[prop] === 'boolean',
+                    'overwriting property must be a boolean');
+            } else if (prop === 'oldByteLength') {
                 assert(typeof params[prop] === 'number' ||
                     params[prop] === null, 'oldByteLength  property must be ' +
                     'an integer or `null`');
@@ -246,8 +251,8 @@ class UtapiClient {
     _getParamsArr(params) {
         this._checkMetricTypes(params);
         const props = [];
-        const { byteLength, newByteLength, oldByteLength, numberOfObjects } =
-            params;
+        const { byteLength, newByteLength, oldByteLength, numberOfObjects,
+            bytesDeleted, overwriting } = params;
         // We add a `service` property to any non-service level to be able to
         // build the appropriate schema key.
         this.metrics.forEach(level => {
@@ -258,9 +263,11 @@ class UtapiClient {
                     level,
                     service: this.service,
                     byteLength,
+                    bytesDeleted,
                     newByteLength,
                     oldByteLength,
                     numberOfObjects,
+                    overwriting,
                 };
                 if (level !== 'service') {
                     obj[prop] = params[prop];
@@ -492,6 +499,10 @@ class UtapiClient {
     * @param {object} params - params for the metrics
     * @param {string} [params.bucket] - (optional) bucket name
     * @param {string} [params.accountId] - (optional) account ID
+    * @param {boolean} params.overwriting - whether the action is overwriting
+    * previous object data
+    * @param {number} params.bytesDeleted - number of bytes deleted by
+    * overwriting data or cleaning up extra parts
     * @param {number} timestamp - normalized timestamp of current time
     * @param {string} action - action metric to update
     * @param {object} log - Werelogs request logger
@@ -500,23 +511,27 @@ class UtapiClient {
     */
     _pushMetricCompleteMultipartUpload(params, timestamp, action, log,
         callback) {
-        this._checkProperties(params);
+        this._checkProperties(params, ['bytesDeleted', 'overwriting']);
         this._logMetric(params, '_pushMetricCompleteMultipartUpload', timestamp,
             log);
+        const { bytesDeleted, overwriting } = params;
+        // if not overwriting data, increment the number of objects
+        const redisCmd = overwriting === true ? 'get' : 'incr';
         const paramsArr = this._getParamsArr(params);
         const cmds = [];
         paramsArr.forEach(p => {
             cmds.push(
-                ['incr', generateCounter(p, 'numberOfObjectsCounter')],
+                ['decrby', generateCounter(p, 'storageUtilizedCounter'),
+                    bytesDeleted],
+                [redisCmd, generateCounter(p, 'numberOfObjectsCounter')],
                 ['incr', generateKey(p, action, timestamp)]
             );
         });
         // We track the number of commands needed for each `paramsArr` object to
         // eventually locate each group in the results from Redis.
-        const commandsGroupSize = 2;
         return this.ds.batch(cmds, (err, results) => {
             if (err) {
-                log.error('error incrementing counter for push metric', {
+                log.error('error pushing metric', {
                     method: 'UtapiClient._pushMetricCompleteMultipartUpload',
                     metric: 'number of objects',
                     error: err,
@@ -527,15 +542,38 @@ class UtapiClient {
             // number of objects counters
             let actionErr;
             let actionCounter;
-            let key;
+            let storageIndex;
+            let objectsIndex;
+            const cmdsLen = cmds.length;
+            const paramsArrLen = paramsArr.length;
             const cmds2 = [];
             const noErr = paramsArr.every((p, i) => {
-                // We want the first element of every group of two commands
-                // returned from Redis.
-                const index = i * commandsGroupSize;
-                actionErr = results[index][0];
-                actionCounter = parseInt(results[index][1], 10);
-                 // If < 0, record numberOfObjects as though bucket were empty.
+                // storage utilized counter
+                storageIndex = (i * (cmdsLen / paramsArrLen));
+                actionErr = results[storageIndex][0];
+                actionCounter = parseInt(results[storageIndex][1], 10);
+                if (actionErr) {
+                    log.error('error incrementing counter for push metric', {
+                        method: 'UtapiClient._pushMetricCompleteMultipart' +
+                            'Upload',
+                        metric: 'storage utilized',
+                        error: actionErr,
+                    });
+                    this._pushLocalCache(params, action, timestamp, log,
+                        callback);
+                    return false;
+                }
+                cmds2.push(
+                    ['zremrangebyscore',
+                        generateStateKey(p, 'storageUtilized'),
+                        timestamp, timestamp],
+                    ['zadd', generateStateKey(p, 'storageUtilized'),
+                        timestamp, actionCounter]);
+                        // number of objects counter
+                objectsIndex = (i * (cmdsLen / paramsArrLen)) + 1;
+                actionErr = results[objectsIndex][0];
+                actionCounter = parseInt(results[objectsIndex][1], 10);
+                // If < 0, record numberOfObjects as though bucket were empty.
                 actionCounter = actionCounter < 0 ? 1 : actionCounter;
                 if (actionErr) {
                     log.error('error incrementing counter for push metric', {
@@ -548,9 +586,12 @@ class UtapiClient {
                         callback);
                     return false;
                 }
-                key = generateStateKey(p, 'numberOfObjects');
-                cmds2.push(['zremrangebyscore', key, timestamp, timestamp],
-                ['zadd', key, timestamp, actionCounter]);
+                cmds2.push(
+                    ['zremrangebyscore',
+                        generateStateKey(p, 'numberOfObjects'),
+                        timestamp, timestamp],
+                    ['zadd', generateStateKey(p, 'numberOfObjects'),
+                        timestamp, actionCounter]);
                 return true;
             });
             if (noErr) {

--- a/lib/UtapiClient.js
+++ b/lib/UtapiClient.js
@@ -572,8 +572,11 @@ class UtapiClient {
                 objectsIndex = (i * (cmdsLen / paramsArrLen)) + 1;
                 actionErr = results[objectsIndex][0];
                 actionCounter = parseInt(results[objectsIndex][1], 10);
-                // If < 0, record numberOfObjects as though bucket were empty.
-                actionCounter = actionCounter < 0 ? 1 : actionCounter;
+                // If the key does not exist, actionCounter will be null.
+                // Hence we check that action counter is a number and is > 0. If
+                // true, we record numberOfObjects as though bucket were empty.
+                actionCounter = Number.isNaN(actionCounter) ||
+                    actionCounter < 0 ? 1 : actionCounter;
                 if (actionErr) {
                     log.error('error incrementing counter for push metric', {
                         method: 'UtapiClient._pushMetricCompleteMultipart' +

--- a/tests/functional/testReplay.js
+++ b/tests/functional/testReplay.js
@@ -100,8 +100,8 @@ function getParams(action) {
         });
     case 'completeMultipartUpload':
         return Object.assign(resources, {
-            bytesDeleted: 0,
-            overwriting: false,
+            byteLength: 0,
+            isOverwrite: false,
         });
     default:
         return resources;

--- a/tests/functional/testReplay.js
+++ b/tests/functional/testReplay.js
@@ -98,6 +98,11 @@ function getParams(action) {
             byteLength: objSize,
             numberOfObjects: 2,
         });
+    case 'completeMultipartUpload':
+        return Object.assign(resources, {
+            bytesDeleted: 0,
+            overwriting: false,
+        });
     default:
         return resources;
     }

--- a/tests/functional/testUtapiClient.js
+++ b/tests/functional/testUtapiClient.js
@@ -113,8 +113,11 @@ function _checkMissingOperations(assertKeys, metricObj, operation, valuesObject,
                     Object.assign(metricObj, {
                         newByteLength: 9,
                         oldByteLength: null,
-                    }), utapiClient.pushMetric('completeMultipartUpload',
-                        reqUid, metricObj, next));
+                    }), () => utapiClient.pushMetric('completeMultipartUpload',
+                        reqUid, {
+                            byteLength: 0,
+                            isOverwrite: false,
+                        }, next));
             default:
                 return next();
             }

--- a/tests/unit/testUtapiClient.js
+++ b/tests/unit/testUtapiClient.js
@@ -123,7 +123,6 @@ describe('UtapiClient:: push metrics', () => {
     beforeEach(() => {
         params = {
             byteLength: undefined,
-            bytesDeleted: undefined,
             overwriting: undefined,
             newByteLength: undefined,
             oldByteLength: undefined,
@@ -236,7 +235,7 @@ describe('UtapiClient:: push metrics', () => {
             storageUtilized: '1024',
         });
         Object.assign(params, metricTypes, {
-            bytesDeleted: 1024,
+            byteLength: 1024,
             overwriting: false,
         });
         const data = { storageUtilized: '2048' };
@@ -252,7 +251,7 @@ describe('UtapiClient:: push metrics', () => {
             storageUtilized: '1',
         });
         Object.assign(params, metricTypes, {
-            bytesDeleted: 2047,
+            byteLength: 2047,
             overwriting: true,
         });
         const data = { storageUtilized: '2048', numberOfObjects: '1' };

--- a/tests/unit/testUtapiClient.js
+++ b/tests/unit/testUtapiClient.js
@@ -123,6 +123,8 @@ describe('UtapiClient:: push metrics', () => {
     beforeEach(() => {
         params = {
             byteLength: undefined,
+            bytesDeleted: undefined,
+            overwriting: undefined,
             newByteLength: undefined,
             oldByteLength: undefined,
             numberOfObjects: undefined,
@@ -231,8 +233,32 @@ describe('UtapiClient:: push metrics', () => {
         const expected = getObject(timestamp, {
             action: 'CompleteMultipartUpload',
             numberOfObjects: '1',
+            storageUtilized: '1024',
         });
-        testMetric('completeMultipartUpload', metricTypes, expected, done);
+        Object.assign(params, metricTypes, {
+            bytesDeleted: 1024,
+            overwriting: false,
+        });
+        const data = { storageUtilized: '2048' };
+        setMockData(data, timestamp, () =>
+            testMetric('completeMultipartUpload', params, expected, done)
+        );
+    });
+
+    it('should push metric for completeMultipartUpload overwrite', done => {
+        const expected = getObject(timestamp, {
+            action: 'CompleteMultipartUpload',
+            numberOfObjects: '1',
+            storageUtilized: '1',
+        });
+        Object.assign(params, metricTypes, {
+            bytesDeleted: 2047,
+            overwriting: true,
+        });
+        const data = { storageUtilized: '2048', numberOfObjects: '1' };
+        setMockData(data, timestamp, () =>
+            testMetric('completeMultipartUpload', params, expected, done)
+        );
     });
 
     it('should push listMultipartUploads metrics', done => {

--- a/tests/unit/testUtapiClient.js
+++ b/tests/unit/testUtapiClient.js
@@ -123,7 +123,7 @@ describe('UtapiClient:: push metrics', () => {
     beforeEach(() => {
         params = {
             byteLength: undefined,
-            overwriting: undefined,
+            isOverwrite: undefined,
             newByteLength: undefined,
             oldByteLength: undefined,
             numberOfObjects: undefined,
@@ -236,7 +236,7 @@ describe('UtapiClient:: push metrics', () => {
         });
         Object.assign(params, metricTypes, {
             byteLength: 1024,
-            overwriting: false,
+            isOverwrite: false,
         });
         const data = { storageUtilized: '2048' };
         setMockData(data, timestamp, () =>
@@ -252,7 +252,7 @@ describe('UtapiClient:: push metrics', () => {
         });
         Object.assign(params, metricTypes, {
             byteLength: 2047,
-            overwriting: true,
+            isOverwrite: true,
         });
         const data = { storageUtilized: '2048', numberOfObjects: '1' };
         setMockData(data, timestamp, () =>


### PR DESCRIPTION
Dependency of https://github.com/scality/S3/pull/1053 and https://github.com/scality/Integration/pull/614

Changes include:
- if complete mpu is overwriting a previous object, we do not increment numberOfObjects metric
- we track bytes deleted for overwriting an object or deleting extra parts to decrby the storageUtilized metrics