### PR TITLE
bf: ZENKO 676 - only location metrics

### DIFF
--- a/lib/UtapiClient.js
+++ b/lib/UtapiClient.js
@@ -89,12 +89,21 @@ class UtapiClient {
         this.disableClient = true;
 
         if (config) {
+            this.disableClient = false;
+            this.expireMetrics = config.expireMetrics;
+            this.expireTTL = config.expireTTL || 0;
+
             if (config.metrics) {
                 const message = 'invalid property in UtapiClient configuration';
                 assert(Array.isArray(config.metrics), `${message}: metrics ` +
                     'must be an array');
                 assert(config.metrics.length !== 0, `${message}: metrics ` +
                     'array cannot be empty');
+                // if location is the only metric, pushMetric should be disabled
+                if (config.metrics.length === 1 &&
+                config.metrics[0] === 'location') {
+                    this.disableClient = true;
+                }
                 this.metrics = config.metrics;
             }
             if (config.redis) {
@@ -110,9 +119,6 @@ class UtapiClient {
                 // internally this is known as a metric level `service`.
                 this.service = config.component;
             }
-            this.disableClient = false;
-            this.expireMetrics = config.expireMetrics;
-            this.expireTTL = config.expireTTL || 0;
         }
     }
 


### PR DESCRIPTION
If utapi.metrics only contains `location`, then UtapiClient should be disabled for pushMetric