### PR TITLE
improvement: reply arsenal errors to the client

### DIFF
--- a/lib/UtapiClient.js
+++ b/lib/UtapiClient.js
@@ -1005,8 +1005,7 @@ class UtapiClient {
                         method: 'UtapiClient.pushLocationMetric',
                         error: err,
                     });
-                    return this._pushLocalCache(params, 'locationStorage', null,
-                        log, callback);
+                    return callback(errors.InternalError);
                 }
                 return callback();
             });
@@ -1033,7 +1032,7 @@ class UtapiClient {
                     method: 'UtapiClient: getLocationMetric',
                     error: err,
                 });
-                return callback(err);
+                return callback(errors.InternalError);
             }
             // if err and bytesStored are null, key does not exist yet
             if (bytesStored === null) {


### PR DESCRIPTION
Without replying Arsenal style errors, the lib breaks the contract and causes an
exception on the cloudserver