### PR TITLE
bugfix: S3C-1506 Prevent heap memory issue

### DIFF
--- a/src/lib/ListMetrics.js
+++ b/src/lib/ListMetrics.js
@@ -5,6 +5,8 @@ import s3metricResponseJSON from '../../models/s3metricResponse';
 import config from './Config';
 import Vault from './Vault';
 
+const MAX_RANGE_MS = (((1000 * 60) * 60) * 24) * 30; // One month.
+
 /**
 * Provides methods to get metrics of different levels
 */
@@ -147,6 +149,54 @@ export default class ListMetrics {
         return res;
     }
 
+    _buildSubRanges(range) {
+        let start = range[0];
+        const end = range[1] || Date.now();
+        const subRangesCount = Math.floor((end - start) / MAX_RANGE_MS) + 1;
+        const subRanges = [];
+        for (let i = 0; i < subRangesCount; i++) {
+            if (i + 1 === subRangesCount) {
+                subRanges.push([start, end]);
+            } else {
+                subRanges.push([start, (start + (MAX_RANGE_MS - 1))]);
+                start = start + MAX_RANGE_MS;
+            }
+        }
+        return subRanges;
+    }
+
+    _reduceResults(results) {
+        const reducer = (accumulator, current) => {
+            const result = Object.assign({}, accumulator);
+            result.timeRange[1] = current.timeRange[1]; // Get the end time.
+            result.storageUtilized[0] += current.storageUtilized[0];
+            result.storageUtilized[1] += current.storageUtilized[1];
+            result.numberOfObjects[0] += current.numberOfObjects[0];
+            result.numberOfObjects[1] += current.numberOfObjects[1];
+            result.incomingBytes += current.incomingBytes;
+            result.outgoingBytes += current.outgoingBytes;
+            const operations = Object.keys(result.operations);
+            operations.forEach(operation => {
+                result.operations[operation] += current.operations[operation];
+            });
+            return result;
+        };
+        return results.reduce(reducer);
+    }
+
+    getMetrics(resource, range, datastore, log, cb) {
+        const ranges = this._buildSubRanges(range);
+        async.mapLimit(ranges, 5, (subRange, next) =>
+            this._getMetricsRange(resource, subRange, datastore, log, next),
+        (err, results) => {
+            if (err) {
+                return cb(err);
+            }
+            const response = this._reduceResults(results);
+            return cb(null, response);
+        });
+    }
+
     /**
     * Callback for getting metrics for a single resource
     * @callback ListMetrics~getMetricsCb
@@ -178,9 +228,9 @@ export default class ListMetrics {
     * @param {ListMetrics~getMetricsCb} cb - callback
     * @return {undefined}
     */
-    getMetrics(resource, range, datastore, log, cb) {
+    _getMetricsRange(resource, range, datastore, log, cb) {
         const start = range[0];
-        const end = range[1] || Date.now();
+        const end = range[1];
         const obj = this._getSchemaObject(resource);
 
         // find nearest neighbors for absolutes

--- a/tests/testUtils.js
+++ b/tests/testUtils.js
@@ -37,3 +37,51 @@ export function getAllResourceTypeKeys() {
     // Concatenate each array of resourceType keys into one single array.
     return [].concat.apply([], allResourceTypeKeys);
 }
+
+export function buildMockResponse({ start, end, val }) {
+    return {
+        timeRange: [start, end],
+        storageUtilized: [val, val],
+        incomingBytes: val,
+        outgoingBytes: val,
+        numberOfObjects: [val, val],
+        operations: {
+            's3:DeleteBucket': val,
+            's3:DeleteBucketCors': val,
+            's3:DeleteBucketWebsite': val,
+            's3:DeleteObjectTagging': val,
+            's3:ListBucket': val,
+            's3:GetBucketAcl': val,
+            's3:GetBucketCors': val,
+            's3:GetBucketWebsite': val,
+            's3:GetBucketLocation': val,
+            's3:CreateBucket': val,
+            's3:PutBucketAcl': val,
+            's3:PutBucketCors': val,
+            's3:PutBucketWebsite': val,
+            's3:PutObject': val,
+            's3:CopyObject': val,
+            's3:UploadPart': val,
+            's3:ListBucketMultipartUploads': val,
+            's3:ListMultipartUploadParts': val,
+            's3:InitiateMultipartUpload': val,
+            's3:CompleteMultipartUpload': val,
+            's3:AbortMultipartUpload': val,
+            's3:DeleteObject': val,
+            's3:MultiObjectDelete': val,
+            's3:GetObject': val,
+            's3:GetObjectAcl': val,
+            's3:GetObjectTagging': val,
+            's3:PutObjectAcl': val,
+            's3:PutObjectTagging': val,
+            's3:HeadBucket': val,
+            's3:HeadObject': val,
+            's3:PutBucketVersioning': val,
+            's3:GetBucketVersioning': val,
+            's3:PutBucketReplication': val,
+            's3:GetBucketReplication': val,
+            's3:DeleteBucketReplication': val,
+        },
+        bucketName: 'utapi-bucket',
+    };
+}

--- a/tests/unit/testListMetrics.js
+++ b/tests/unit/testListMetrics.js
@@ -1,0 +1,67 @@
+import assert from 'assert';
+import ListMetrics from '../../src/lib/ListMetrics';
+import { buildMockResponse } from '../testUtils';
+
+const MAX_RANGE_MS = (((1000 * 60) * 60) * 24) * 30; // One month.
+
+describe('ListMetrics', () => {
+    const listMetrics = new ListMetrics();
+
+    describe('::_buildSubRanges', () => {
+        const tests = [
+            {
+                range: [0, MAX_RANGE_MS - 1],
+                expected: [[0, MAX_RANGE_MS - 1]],
+            },
+            {
+                range: [0, (MAX_RANGE_MS * 2) - 1],
+                expected: [
+                    [0, MAX_RANGE_MS - 1],
+                    [MAX_RANGE_MS, (MAX_RANGE_MS * 2) - 1],
+                ],
+            },
+        ];
+        tests.forEach(test => {
+            const { range, expected } = test;
+            it(`should create sub-ranges, given range ${range}`, () => {
+                const ranges = listMetrics._buildSubRanges(range);
+                assert.deepStrictEqual(ranges, expected);
+            });
+        });
+
+        it('should set end date to the current time if not provided', () => {
+            const testStartTime = Date.now();
+            const range = [testStartTime - ((1000 * 60) * 15)];
+            const ranges = listMetrics._buildSubRanges(range);
+            assert.strictEqual(ranges.length, 1);
+            assert.strictEqual(ranges[0][0], range[0]);
+            assert(ranges[0][1] >= testStartTime && ranges[0][1] <= Date.now());
+        });
+    });
+
+    describe('::_reduceResults', () => {
+        const tests = [
+            {
+                results: [
+                    buildMockResponse({ start: 0, end: 1, val: 1 }),
+                ],
+                expected:
+                    buildMockResponse({ start: 0, end: 1, val: 1 }),
+            },
+            {
+                results: [
+                    buildMockResponse({ start: 0, end: 1, val: 1 }),
+                    buildMockResponse({ start: 2, end: 3, val: 1 }),
+                ],
+                expected:
+                    buildMockResponse({ start: 0, end: 3, val: 2 }),
+            },
+        ];
+        tests.forEach(test => {
+            const { results, expected } = test;
+            const result = listMetrics._reduceResults(results);
+            it(`should reduce ${results.length} result(s)`, () =>
+                assert.deepStrictEqual(result, expected));
+        });
+    });
+});


### PR DESCRIPTION
When fetching longer-ranged metrics (e.g. >= 1 year), the V8 managed heap runs out of memory due to the high number of actions required to perform the metrics computation.

```
<--- Last few GCs --->

  216154 ms: Mark-sweep 1333.3 (1436.0) -> 1333.2 (1436.0) MB, 1277.8 / 0.0 ms [allocation failure] [scavenge might not succeed].
  217628 ms: Mark-sweep 1333.3 (1436.0) -> 1333.3 (1436.0) MB, 1473.2 / 0.0 ms [allocation failure] [scavenge might not succeed].
  219441 ms: Mark-sweep 1333.3 (1436.0) -> 1333.3 (1436.0) MB, 1813.5 / 0.0 ms [allocation failure] [GC in old space requested].


<--- JS stacktrace --->
Cannot get stack trace in GC.
FATAL ERROR: MarkCompactCollector: semi-space copy, fallback in old gen Allocation failed - JavaScript heap out of memory
[...]
```

This PR limits the range request to one month by mapping a longer ranges into sub ranges and then reducing the results back into a single response.