### PR TITLE
bugfix: S3C-2155 Time range validation

### DIFF
--- a/src/validators/Validator.js
+++ b/src/validators/Validator.js
@@ -26,10 +26,11 @@ const keyError = new Map([
     ['users', errors.InvalidParameterValue],
     ['service', errors.InvalidParameterValue],
     ['timeRange', errors.InvalidParameterValue.customizeDescription(
-        'Timestamps must be one of the following intervals for any day/hour' +
-            ' (mm:ss:SS) - start must be one of [00:00:000, 15:00:000, ' +
-            '30:00:000, 45:00:000], end must be one of [14:59:999,' +
-            ' 29:59:999, 44:59:999, 59:59:999].'
+        'Timestamps must be one of the following intervals for any past ' +
+        'day/hour (mm:ss:SS) - start must be one of [00:00:000, 15:00:000, ' +
+        '30:00:000, 45:00:000], end must be one of [14:59:999, ' +
+        '29:59:999, 44:59:999, 59:59:999]. Start must not be greater than ' +
+        'end.'
     )],
 ]);
 

--- a/src/validators/validateTimeRange.js
+++ b/src/validators/validateTimeRange.js
@@ -37,8 +37,13 @@ export default function validateTimeRange(timeRange) {
                 return false;
             }
         }
-
-        if (timeRange[0] > timeRange[1]) {
+        const now = Date.now();
+        // If end is not provided, it is later set as the current timestamp.
+        const endTime = timeRange[1] || now;
+        if (endTime > now) {
+            return false;
+        }
+        if (timeRange[0] > endTime) {
             return false;
         }
         return true;

--- a/tests/unit/validators/validateTimeRange.js
+++ b/tests/unit/validators/validateTimeRange.js
@@ -1,0 +1,33 @@
+import assert from 'assert';
+import validateTimeRange from '../../../src/validators/validateTimeRange';
+import { getNormalizedTimestamp } from '../../testUtils';
+
+describe('validateTimeRange', () => {
+    const fifteenMinutes = (1000 * 60) * 15;
+
+    it('should allow a current end time, if not provided', () => {
+        const start = getNormalizedTimestamp();
+        const isValid = validateTimeRange([start]);
+        assert.strictEqual(isValid, true);
+    });
+
+    it('should not allow a start time in the future', () => {
+        const start = getNormalizedTimestamp() + fifteenMinutes;
+        const isValid = validateTimeRange([start]);
+        assert.strictEqual(isValid, false);
+    });
+
+    it('should not allow an end time in the future', () => {
+        const start = getNormalizedTimestamp();
+        const end = getNormalizedTimestamp() + fifteenMinutes - 1;
+        const isValid = validateTimeRange([start, end]);
+        assert.strictEqual(isValid, false);
+    });
+
+    it('should not allow a start time greater than the end time', () => {
+        const start = getNormalizedTimestamp() - (fifteenMinutes * 2);
+        const end = getNormalizedTimestamp() - (fifteenMinutes * 3) - 1;
+        const isValid = validateTimeRange([start, end]);
+        assert.strictEqual(isValid, false);
+    });
+});


### PR DESCRIPTION
I would like to eventually refactor this to allow for custom response messages based on the validation checks themselves. However, these checks will serve in the interim to prevent unexpected behavior related to time ranges.

Changes made:
* Check that both start and end times are in the past
* Do not allow the start time to be greater than the end time, especially in the case where the user does not provide an end time