### PR TITLE
bugfix: S3C-1506 Range requests functional tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@
 
 Service Utilization API for tracking resource usage and metrics reporting
 
+## Server
+
+To run the server:
+
+```
+npm start
+```
+
 ## Client
 
 The module exposes a client, named UtapiClient. Projects can use this client to

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -8,12 +8,20 @@ branches:
 stages:
   pre-merge:
     worker:
-      type: docker
-      path: eve/workers/unit_and_feature_tests
-      volumes:
-        - '/home/eve/workspace'
+      type: local
     steps:
-      - Git:
+    - TriggerStages:
+        name: trigger all the tests
+        stage_names:
+        - run-tests
+  run-tests:
+    worker: &workspace
+      type: kube_pod
+      path: eve/workers/pod.yml
+      images:
+        aggressor: eve/workers/unit_and_feature_tests
+    steps:
+      - Git: &git
           name: fetch source
           repourl: '%(prop:git_reference)s'
           shallow: True
@@ -22,9 +30,10 @@ stages:
       - ShellCommand:
           name: npm install
           command: npm install
-#      - ShellCommand:
-#          name: get api node modules from cache
-#          command: mv /home/eve/node_reqs/node_modules .
+          haltOnFailure: True
+      - ShellCommand:
+          name: npm run postinstall
+          command: npm run postinstall
       - ShellCommand:
           name: run static analysis tools on markdown
           command: npm run lint_md
@@ -36,4 +45,4 @@ stages:
           command: npm test
       - ShellCommand:
           name: run feature tests
-          command: npm run ft_test
+          command: bash ./eve/workers/unit_and_feature_tests/run_ft_tests.bash ft_test

--- a/eve/workers/pod.yml
+++ b/eve/workers/pod.yml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "utapi-test-pod"
+spec:
+  activeDeadlineSeconds: 3600
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 10
+  containers:
+  - name: aggressor
+    image: {{ images.aggressor }}
+    imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: "3"
+        memory: 3Gi
+    volumeMounts:
+    - mountPath: /var/run/docker.sock
+      name: docker-socket
+  volumes:
+  - name: docker-socket
+    hostPath:
+      path: /var/run/docker.sock
+      type: Socket

--- a/eve/workers/unit_and_feature_tests/buildbot_worker_packages.list
+++ b/eve/workers/unit_and_feature_tests/buildbot_worker_packages.list
@@ -7,3 +7,5 @@ python2.7-dev
 python-pip
 sudo
 supervisor
+lsof
+netcat

--- a/eve/workers/unit_and_feature_tests/run_ft_tests.bash
+++ b/eve/workers/unit_and_feature_tests/run_ft_tests.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -x
+set -eu -o pipefail
+
+# port for utapi server
+PORT=8100
+
+trap killandsleep EXIT
+
+killandsleep () {
+  kill -9 $(lsof -t -i:$PORT) || true
+  sleep 10
+}
+
+npm start & bash tests/utils/wait_for_local_port.bash $PORT 40
+npm run $1

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ft_test": "mocha --compilers js:babel-core/register --recursive tests/functional",
     "lint": "eslint $(git ls-files '*.js')",
     "lint_md": "mdlint $(git ls-files '*.md')",
-    "start": "node index.js",
+    "start": "node server.js",
     "test": "mocha --compilers js:babel-core/register --recursive tests/unit"
   },
   "private": true

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "werelogs": "scality/werelogs#40b92c54"
   },
   "devDependencies": {
+    "aws4": "^1.8.0",
     "eslint": "^2.4.0",
     "eslint-config-airbnb": "^6.0.0",
     "eslint-config-scality": "scality/Guidelines#71a059ad",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,4 @@
+const config = require('./dist/lib/Config').default;
+const server = require('./dist/lib/server').default;
+
+server(Object.assign({}, config, { component: 's3' }));

--- a/tests/functional/testListMetrics.js
+++ b/tests/functional/testListMetrics.js
@@ -1,0 +1,58 @@
+import assert from 'assert';
+import { makeUtapiClientRequest } from '../utils/utils';
+import Vault from '../utils/mock/Vault';
+
+const MAX_RANGE_MS = (((1000 * 60) * 60) * 24) * 30; // One month.
+
+describe('Request ranges', function test() {
+    this.timeout((1000 * 60) * 2);
+
+    before(() => {
+        const vault = new Vault();
+        vault.start();
+    });
+
+    const tests = [
+        {
+            start: 0,
+            end: ((MAX_RANGE_MS / 60) - (1000 * 60) * 15) - 1,
+        },
+        {
+            start: 0,
+            end: MAX_RANGE_MS - 1,
+        },
+        {
+            start: 0,
+            end: (MAX_RANGE_MS + (1000 * 60) * 15) - 1,
+        },
+        {
+            start: 0,
+            end: (MAX_RANGE_MS * 12) - 1,
+        },
+    ];
+
+    tests.forEach(test => {
+        const { start, end } = test;
+        it(`should handle a request range of ${end - start}ms`, done => {
+            const params = {
+                timeRange: [start, end],
+                resource: {
+                    type: 'buckets',
+                    buckets: ['my-bucket'],
+                },
+            };
+            makeUtapiClientRequest(params, (err, response) => {
+                if (err) {
+                    return done(err);
+                }
+                const data = JSON.parse(response);
+                if (data.code) {
+                    return done(new Error(data.message));
+                }
+                const { timeRange } = data[0];
+                assert.deepStrictEqual(timeRange, [start, end]);
+                return done();
+            });
+        });
+    });
+});

--- a/tests/functional/testReplay.js
+++ b/tests/functional/testReplay.js
@@ -5,7 +5,7 @@ import UtapiReplay from '../../src/lib/UtapiReplay';
 import UtapiClient from '../../src/lib/UtapiClient';
 import Datastore from '../../src/lib/Datastore';
 import redisClient from '../../src/utils/redisClient';
-import { getAllResourceTypeKeys } from '../testUtils';
+import { getAllResourceTypeKeys } from '../utils/utils';
 import safeJsonParse from '../../src/utils/safeJsonParse';
 const localCache = redisClient({
     host: '127.0.0.1',

--- a/tests/unit/testListMetrics.js
+++ b/tests/unit/testListMetrics.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import ListMetrics from '../../src/lib/ListMetrics';
-import { buildMockResponse } from '../testUtils';
+import { buildMockResponse } from '../utils/utils';
 
 const MAX_RANGE_MS = (((1000 * 60) * 60) * 24) * 30; // One month.
 

--- a/tests/unit/testUtapiClient.js
+++ b/tests/unit/testUtapiClient.js
@@ -3,7 +3,7 @@ import { Logger } from 'werelogs';
 import Datastore from '../../src/lib/Datastore';
 import MemoryBackend from '../../src/lib/backend/Memory';
 import UtapiClient from '../../src/lib/UtapiClient';
-import { getNormalizedTimestamp } from '../testUtils';
+import { getNormalizedTimestamp } from '../utils/utils';
 
 const memoryBackend = new MemoryBackend();
 const ds = new Datastore();

--- a/tests/unit/validators/validateTimeRange.js
+++ b/tests/unit/validators/validateTimeRange.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import validateTimeRange from '../../../src/validators/validateTimeRange';
-import { getNormalizedTimestamp } from '../../testUtils';
+import { getNormalizedTimestamp } from '../../utils/utils';
 
 describe('validateTimeRange', () => {
     const fifteenMinutes = (1000 * 60) * 15;

--- a/tests/utils/mock/Vault.js
+++ b/tests/utils/mock/Vault.js
@@ -1,0 +1,17 @@
+const http = require('http');
+
+const config = require('../../../src/lib/Config').default;
+
+class Vault {
+    _onRequest(req, res) {
+        res.writeHead(200);
+        return res.end();
+    }
+
+    start() {
+        const { port } = config.vaultd;
+        return http.createServer(this._onRequest).listen(port);
+    }
+}
+
+module.exports = Vault;

--- a/tests/utils/wait_for_local_port.bash
+++ b/tests/utils/wait_for_local_port.bash
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+wait_for_local_port() {
+    local port=$1
+    local timeout=$2
+    local count=0
+    local ret=1
+    echo "waiting for UtapiServer:$port"
+    while [[ "$ret" -eq "1" && "$count" -lt "$timeout" ]] ; do
+        nc -z -w 1 localhost $port
+        ret=$?
+        if [ ! "$ret" -eq "0" ]; then
+            echo -n .
+            sleep 1
+            count=$(($count+1))
+        fi
+    done
+
+    echo ""
+
+    if [[ "$count" -eq "$timeout" ]]; then
+        echo "Server did not start in less than $timeout seconds. Exiting..."
+        exit 1
+    fi
+    sleep 5
+
+    echo "Server got ready in ~${count} seconds. Starting test now..."
+}
+
+wait_for_local_port $1 $2


### PR DESCRIPTION
Adds functional tests for longer range (i.e. >= 1 year) metrics requests to ensure V8 managed heap memory limit is not exceeded.

To run this particular test, the UTAPI server is needed. The PR is divided into two commits, the first adds the infrastructure to run the server in Eve, and the second introduces the tests. It might be helpful to review each independently.