### PR TITLE
bugfix: S3C-1506 Update start/end reducer

### DIFF
--- a/src/lib/ListMetrics.js
+++ b/src/lib/ListMetrics.js
@@ -168,11 +168,9 @@ export default class ListMetrics {
     _reduceResults(results) {
         const reducer = (accumulator, current) => {
             const result = Object.assign({}, accumulator);
-            result.timeRange[1] = current.timeRange[1]; // Get the end time.
-            result.storageUtilized[0] += current.storageUtilized[0];
-            result.storageUtilized[1] += current.storageUtilized[1];
-            result.numberOfObjects[0] += current.numberOfObjects[0];
-            result.numberOfObjects[1] += current.numberOfObjects[1];
+            result.timeRange[1] = current.timeRange[1];
+            result.storageUtilized[1] = current.storageUtilized[1];
+            result.numberOfObjects[1] = current.numberOfObjects[1];
             result.incomingBytes += current.incomingBytes;
             result.outgoingBytes += current.outgoingBytes;
             const operations = Object.keys(result.operations);

--- a/tests/unit/testListMetrics.js
+++ b/tests/unit/testListMetrics.js
@@ -43,18 +43,78 @@ describe('ListMetrics', () => {
         const tests = [
             {
                 results: [
-                    buildMockResponse({ start: 0, end: 1, val: 1 }),
+                    buildMockResponse({
+                        start: {
+                            time: 0,
+                            storageUtilized: 0,
+                            numberOfObjects: 0,
+                        },
+                        end: {
+                            time: 1,
+                            storageUtilized: 1,
+                            numberOfObjects: 1,
+                        },
+                        val: 1,
+                    }),
                 ],
                 expected:
-                    buildMockResponse({ start: 0, end: 1, val: 1 }),
+                    buildMockResponse({
+                        start: {
+                            time: 0,
+                            storageUtilized: 0,
+                            numberOfObjects: 0,
+                        },
+                        end: {
+                            time: 1,
+                            storageUtilized: 1,
+                            numberOfObjects: 1,
+                        },
+                        val: 1,
+                    }),
             },
             {
                 results: [
-                    buildMockResponse({ start: 0, end: 1, val: 1 }),
-                    buildMockResponse({ start: 2, end: 3, val: 1 }),
+                    buildMockResponse({
+                        start: {
+                            time: 0,
+                            storageUtilized: 0,
+                            numberOfObjects: 0,
+                        },
+                        end: {
+                            time: 1,
+                            storageUtilized: 1,
+                            numberOfObjects: 1,
+                        },
+                        val: 1,
+                    }),
+                    buildMockResponse({
+                        start: {
+                            time: 2,
+                            storageUtilized: 1,
+                            numberOfObjects: 1,
+                        },
+                        end: {
+                            time: 3,
+                            storageUtilized: 2,
+                            numberOfObjects: 2,
+                        },
+                        val: 1,
+                    }),
                 ],
                 expected:
-                    buildMockResponse({ start: 0, end: 3, val: 2 }),
+                    buildMockResponse({
+                        start: {
+                            time: 0,
+                            storageUtilized: 0,
+                            numberOfObjects: 0,
+                        },
+                        end: {
+                            time: 3,
+                            storageUtilized: 2,
+                            numberOfObjects: 2,
+                        },
+                        val: 2,
+                    }),
             },
         ];
         tests.forEach(test => {

--- a/tests/utils/utils.js
+++ b/tests/utils/utils.js
@@ -43,11 +43,11 @@ export function getAllResourceTypeKeys() {
 
 export function buildMockResponse({ start, end, val }) {
     return {
-        timeRange: [start, end],
-        storageUtilized: [val, val],
+        timeRange: [start.time, end.time],
+        storageUtilized: [start.storageUtilized, end.storageUtilized],
         incomingBytes: val,
         outgoingBytes: val,
-        numberOfObjects: [val, val],
+        numberOfObjects: [start.numberOfObjects, end.numberOfObjects],
         operations: {
             's3:DeleteBucket': val,
             's3:DeleteBucketCors': val,


### PR DESCRIPTION
The values `storageUtilized` and `numberOfObjects` should be an array where the 0th element is the value of the first response, and the 1st element is the value of the last response, rather than a sum of values. I.e. the same logic as `timeRange`.