### PR TITLE
bugfix: S3C-2105 Add put data metric

### DIFF
--- a/lib/UtapiClient.js
+++ b/lib/UtapiClient.js
@@ -39,6 +39,7 @@ const methods = {
     getObjectTagging: { method: '_genericPushMetric', changesData: false },
     putObject: { method: '_genericPushMetricPutObject', changesData: true },
     copyObject: { method: '_genericPushMetricPutObject', changesData: true },
+    putData: { method: '_genericPushMetricPutObject', changesData: true },
     putObjectAcl: { method: '_genericPushMetric', changesData: true },
     putObjectTagging: { method: '_genericPushMetric', changesData: true },
     deleteObjectTagging: { method: '_genericPushMetric', changesData: true },
@@ -885,10 +886,12 @@ class UtapiClient {
             cmds.push(
                 ['incrby', generateCounter(p, 'storageUtilizedCounter'),
                     storageUtilizedDelta],
-                [redisCmd, generateCounter(p, 'numberOfObjectsCounter')],
-                ['incr', generateKey(p, action, timestamp)]
+                [redisCmd, generateCounter(p, 'numberOfObjectsCounter')]
             );
-            if (action === 'putObject') {
+            if (action !== 'putData') {
+                cmds.push(['incr', generateKey(p, action, timestamp)]);
+            }
+            if (action === 'putObject' || action === 'putData') {
                 cmds.push(
                     ['incrby', generateKey(p, 'incomingBytes', timestamp),
                         newByteLength]

--- a/tests/unit/testUtapiClient.js
+++ b/tests/unit/testUtapiClient.js
@@ -71,8 +71,10 @@ function getObject(timestamp, data) {
     const prefixValuesArr = getPrefixValues(timestamp);
     prefixValuesArr.forEach(type => {
         const { key, timestampKey } = type;
-        // The action is always incremented to one in the tests
-        obj[`${timestampKey}:${data.action}`] = '1';
+        if (data.action) {
+            // The action is always incremented to one in the tests
+            obj[`${timestampKey}:${data.action}`] = '1';
+        }
         // The expected object is constructed based on the `data` object
         Object.keys(data).forEach(metric => {
             if (metric === 'storageUtilized') {
@@ -386,6 +388,19 @@ describe('UtapiClient:: push metrics', () => {
         };
         setMockData(data, timestamp, () =>
             testMetric('copyObject', params, expected, done));
+    });
+
+    it('should push putData metrics', done => {
+        const expected = getObject(timestamp, {
+            storageUtilized: '1024',
+            numberOfObjects: '1',
+            incomingBytes: '1024',
+        });
+        Object.assign(params, metricTypes, {
+            newByteLength: 1024,
+            oldByteLength: null,
+        });
+        testMetric('putData', params, expected, done);
     });
 
     it('should push putObjectAcl metrics', done => {


### PR DESCRIPTION
Add a `putData` metric which corresponds to the route backbeat method `putData` which serves as the endpoint for replicated data operations.