### PR TITLE
bugfix: S3C-2155 Allow end time in the future

### DIFF
--- a/src/validators/validateTimeRange.js
+++ b/src/validators/validateTimeRange.js
@@ -40,9 +40,6 @@ export default function validateTimeRange(timeRange) {
         const now = Date.now();
         // If end is not provided, it is later set as the current timestamp.
         const endTime = timeRange[1] || now;
-        if (endTime > now) {
-            return false;
-        }
         if (timeRange[0] > endTime) {
             return false;
         }

--- a/tests/unit/validators/validateTimeRange.js
+++ b/tests/unit/validators/validateTimeRange.js
@@ -17,13 +17,6 @@ describe('validateTimeRange', () => {
         assert.strictEqual(isValid, false);
     });
 
-    it('should not allow an end time in the future', () => {
-        const start = getNormalizedTimestamp();
-        const end = getNormalizedTimestamp() + fifteenMinutes - 1;
-        const isValid = validateTimeRange([start, end]);
-        assert.strictEqual(isValid, false);
-    });
-
     it('should not allow a start time greater than the end time', () => {
         const start = getNormalizedTimestamp() - (fifteenMinutes * 2);
         const end = getNormalizedTimestamp() - (fifteenMinutes * 3) - 1;


### PR DESCRIPTION
It is possible that some existing requests use an end time that is in the future (e.g. Integration tests use such a range). It's possible that we may want to revise the API specifications, perhaps when migrating UTAPI to the Zenko stack. However currently the risk of breaking compatibility is too great.