### PR TITLE
S3C-2034: bump ioredis to use redis 5.x features

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "arsenal": "scality/Arsenal#67365083",
     "async": "^2.0.1",
-    "ioredis": "^2.3.0",
+    "ioredis": "^4.9.5",
     "node-schedule": "1.2.0",
     "vaultclient": "scality/vaultclient#fbd9988d",
     "werelogs": "scality/werelogs#0ff7ec82"


### PR DESCRIPTION
dependent on https://github.com/scality/Arsenal/pull/795