### PR TITLE
INTEGRATION [PR#249 > development/8.0] S3C-2034: bump ioredis to use redis 5.x features

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "arsenal": "scality/Arsenal#67365083",
     "async": "^2.0.1",
-    "ioredis": "^2.3.0",
+    "ioredis": "^4.9.5",
     "node-schedule": "1.2.0",
     "vaultclient": "scality/vaultclient#fbd9988d",
     "werelogs": "scality/werelogs#0ff7ec82"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #249.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.0/improvement/S3C-2034-bump-ioredis-version`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.0/improvement/S3C-2034-bump-ioredis-version
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.0/improvement/S3C-2034-bump-ioredis-version
```

Please always comment pull request #249 instead of this one.