### PR TITLE
bugfix: S3C-2076 Add UtapiReindex

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,4 +3,5 @@ module.exports = {
     UtapiServer: require('./lib/server.js'),
     UtapiClient: require('./lib/UtapiClient.js'),
     UtapiReplay: require('./lib/UtapiReplay.js'),
+    UtapiReindex: require('./lib/UtapiReindex.js'),
 };

--- a/lib/Datastore.js
+++ b/lib/Datastore.js
@@ -37,7 +37,7 @@ class Datastore {
     }
 
     /**
-    * Set the replay lock key (if it does not already exist) with an expiration
+    * Set a lock key, if it does not already exist, with an expiration
     * @param {string} key - key to set with an expiration
     * @param {string} value - value containing the data
     * @param {string} ttl - time after which the key expires

--- a/lib/UtapiReindex.js
+++ b/lib/UtapiReindex.js
@@ -1,0 +1,210 @@
+const childProcess = require('child_process');
+
+const async = require('async');
+const nodeSchedule = require('node-schedule');
+
+const { jsutil } = require('arsenal');
+const werelogs = require('werelogs');
+
+const Datastore = require('./Datastore');
+const redisClient = require('../utils/redisClient');
+
+const REINDEX_SCHEDULE = '* * * * * 7';
+const REINDEX_LOCK_KEY = 's3:utapireindex:lock';
+const REINDEX_LOCK_TTL = (60 * 60) * 24;
+
+class UtapiReindex {
+
+    constructor(config) {
+        this._enabled = false;
+        this._schedule = REINDEX_SCHEDULE;
+        this._sentinel = {
+            host: '127.0.0.1',
+            port: 16379,
+            name: 'scality-s3',
+        };
+        this._bucketd = {
+            host: '127.0.0.1',
+            port: 9000,
+        };
+        this._log = new werelogs.Logger('UtapiReindex');
+
+        if (config && config.enabled) {
+            this._enabled = config.enabled;
+        }
+        if (config && config.schedule) {
+            this._schedule = config.schedule;
+        }
+        if (config && config.sentinel) {
+            const { host, port, name } = config.sentinel;
+            this._sentinel.host = host || this._sentinel.host;
+            this._sentinel.port = port || this._sentinel.port;
+            this._sentinel.name = name || this._sentinel.name;
+        }
+        if (config && config.bucketd) {
+            const { host, port } = config.bucketd;
+            this._bucketd.host = host || this._bucketd.host;
+            this._bucketd.port = port || this._bucketd.port;
+        }
+        if (config && config.log) {
+            const { level, dump } = config.log;
+            this._log = new werelogs.Logger('UtapiReindex', { level, dump });
+        }
+
+        this._requestLogger = this._log.newRequestLogger();
+    }
+
+    _getRedisClient() {
+        return redisClient({
+            sentinels: [{
+                host: this._sentinel.host,
+                port: this._sentinel.port,
+            }],
+            name: this._sentinel.name,
+        }, this._log);
+    }
+
+    _lock() {
+        return this.ds.setExpire(REINDEX_LOCK_KEY, 'true', REINDEX_LOCK_TTL);
+    }
+
+    _unLock() {
+        return this.ds.del(REINDEX_LOCK_KEY);
+    }
+
+    _runScript(path, done) {
+        const process = childProcess.spawn('python3.4', [
+            path,
+            this._sentinel.host,
+            this._sentinel.port,
+            this._sentinel.name,
+            this._bucketd.host,
+            this._bucketd.port,
+        ]);
+        process.stdout.on('data', data => {
+            this._requestLogger.info('received output from script', {
+                output: Buffer.from(data).toString(),
+                script: path,
+            });
+        });
+        process.stderr.on('data', data => {
+            this._requestLogger.debug('received error from script', {
+                output: Buffer.from(data).toString(),
+                script: path,
+            });
+        });
+        process.on('error', err => {
+            this._requestLogger.debug('failed to start process', {
+                error: err,
+                script: path,
+            });
+        });
+        process.on('close', code => {
+            if (code) {
+                this._requestLogger.error('script exited with error', {
+                    statusCode: code,
+                    script: path,
+                });
+            } else {
+                this._requestLogger.info('script exited successfully', {
+                    statusCode: code,
+                    script: path,
+                });
+            }
+            return done();
+        });
+    }
+
+    _attemptLock(job) {
+        this._requestLogger.info('attempting to acquire the lock to begin job');
+        this._lock()
+            .then(res => {
+                if (res) {
+                    this._requestLogger
+                        .info('acquired the lock, proceeding with job');
+                    job();
+                } else {
+                    this._requestLogger
+                        .info('the lock is already acquired, skipping job');
+                }
+            })
+            .catch(err => {
+                this._requestLogger.error(
+                    'an error occurred when acquiring the lock, skipping job', {
+                        stack: err && err.stack,
+                    });
+            });
+    }
+
+    _attemptUnlock() {
+        this._unLock()
+            .catch(err => {
+                this._requestLogger
+                    .error('an error occurred when removing the lock', {
+                        stack: err && err.stack,
+                    });
+            });
+    }
+
+    _connect(done) {
+        const doneOnce = jsutil.once(done);
+        const client = this._getRedisClient();
+        this.ds = new Datastore().setClient(client);
+        client
+            .on('ready', doneOnce)
+            .on('error', doneOnce);
+    }
+
+    _scheduleJob() {
+        this._connect(err => {
+            if (err) {
+                this._requestLogger.error(
+                    'could not connect to datastore, skipping', {
+                        error: err && err.stack,
+                    });
+                return undefined;
+            }
+            return this._attemptLock(() => {
+                const scripts = [
+                    `${__dirname}/reindex/s3_bucketd.py`,
+                    `${__dirname}/reindex/reporting.py`,
+                ];
+                return async.eachSeries(scripts, (script, next) => {
+                    this._runScript(script, next);
+                }, () => {
+                    this._attemptUnlock();
+                });
+            });
+        });
+    }
+
+    _job() {
+        const job =
+            nodeSchedule.scheduleJob(this._schedule, () => this._scheduleJob());
+        if (!job) {
+            this._log.error('could not initiate job schedule');
+            return undefined;
+        }
+        job.on('scheduled', () => {
+            this._requestLogger = this._log.newRequestLogger();
+            this._requestLogger.info('utapi reindex job scheduled', {
+                schedule: this._schedule,
+            });
+        });
+        return undefined;
+    }
+
+    start() {
+        if (this._enabled) {
+            this._log.info('initiating job schedule', {
+                schedule: this._schedule,
+            });
+            this._job();
+        } else {
+            this._log.info('utapi reindex is disabled');
+        }
+        return this;
+    }
+}
+
+module.exports = UtapiReindex;

--- a/lib/reindex/reporting.py
+++ b/lib/reindex/reporting.py
@@ -1,0 +1,102 @@
+import requests
+import redis
+import json
+import ast
+import sys
+import time
+import urllib
+import re
+import sys
+from threading import Thread
+from concurrent.futures import ThreadPoolExecutor
+
+if len(sys.argv) == 6:
+    ip = sys.argv[1]
+    port = sys.argv[2]
+    sentinel_cluster_name = sys.argv[3]
+    bucketd_host = sys.argv[4]
+    bucketd_port = sys.argv[5]
+    print("Sentinel IP used: %s" % ip)
+    print("Sentinel port used: %s" % port)
+    print("Sentinel cluster name used: %s" % sentinel_cluster_name)
+    print("BucketD host used: %s" % bucketd_host)
+    print("BucketD port used: %s" % bucketd_port)
+else:
+    ip = "127.0.0.1"
+    port = "16379"
+    sentinel_cluster_name = "scality-s3"
+    bucketd_host =  "127.0.0.1"
+    bucketd_port = "9000"
+
+
+def safe_print(content):
+    print("{0}".format(content))
+
+
+class askRedis():
+
+    def __init__(self, ip="127.0.0.1", port="16379", sentinel_cluster_name="scality-s3"):
+
+        r = redis.Redis(host=ip, port=port, db=0)
+        self._ip, self._port = r.sentinel_get_master_addr_by_name(sentinel_cluster_name)
+
+    def read(self, resource, name):
+
+        r = redis.Redis(host=self._ip, port=self._port, db=0)
+        res = 's3:%s:%s:storageUtilized:counter' % (resource, name)
+        total_size = r.get(res)
+        res = 's3:%s:%s:numberOfObjects:counter' % (resource, name)
+        files = r.get(res)
+        return {'files': int(files), "total_size": int(total_size)}
+
+
+class S3ListBuckets():
+
+    def __init__(self, ip="127.0.0.1", bucketd_port="9000"):
+
+        self.ip = ip
+        self.bucketd_port = bucketd_port
+
+    def run(self):
+
+        docs = []
+        url = "http://%s:%s/default/bucket/users..bucket" % (self.ip, self.bucketd_port)
+        session = requests.Session()
+        r = session.get(url, timeout=30)
+        if r.status_code == 200:
+            payload = json.loads(r.text)
+            for keys in payload['Contents']:
+                key = keys["key"]
+                r1 = re.match("(\w+)..\|..(\w+.*)", key)
+                docs.append(r1.groups())
+
+        return docs
+
+        return(self.userid, self.bucket, user, files, total_size)
+
+
+P = S3ListBuckets(ip=bucketd_host, bucketd_port=bucketd_port)
+listbuckets = P.run()
+
+userids = set([x for x, y in listbuckets])
+
+executor = ThreadPoolExecutor(max_workers=1)
+for userid, bucket in listbuckets:
+    U = askRedis(ip, port, sentinel_cluster_name)
+    data = U.read('buckets', bucket)
+    content = "Account:%s|Bucket:%s|NumberOFfiles:%s|StorageCapacity:%s " % (
+        userid, bucket, data["files"], data["total_size"])
+    executor.submit(safe_print, content)
+    data = U.read('buckets', 'mpuShadowBucket'+bucket)
+    content = "Account:%s|Bucket:%s|NumberOFfiles:%s|StorageCapacity:%s " % (
+        userid, 'mpuShadowBucket'+bucket, data["files"], data["total_size"])
+    executor.submit(safe_print, content)
+
+
+executor.submit(safe_print, "")
+for userid in sorted(userids):
+    U = askRedis(ip, port, sentinel_cluster_name)
+    data = U.read('accounts', userid)
+    content = "Account:%s|NumberOFfiles:%s|StorageCapacity:%s " % (
+        userid, data["files"], data["total_size"])
+    executor.submit(safe_print, content)

--- a/lib/reindex/s3_bucketd.py
+++ b/lib/reindex/s3_bucketd.py
@@ -1,0 +1,217 @@
+import requests
+import redis
+import json
+import ast
+import sys
+import time
+import urllib
+import re
+import sys
+from threading import Thread
+from concurrent.futures import ThreadPoolExecutor
+
+if len(sys.argv) == 6:
+    ip = sys.argv[1]
+    port = sys.argv[2]
+    sentinel_cluster_name = sys.argv[3]
+    bucketd_host = sys.argv[4]
+    bucketd_port = sys.argv[5]
+    print("Sentinel IP used: %s" % ip)
+    print("Sentinel port used: %s" % port)
+    print("Sentinel cluster name used: %s" % sentinel_cluster_name)
+    print("BucketD host used: %s" % bucketd_host)
+    print("BucketD port used: %s" % bucketd_port)
+else:
+    ip = "127.0.0.1"
+    port = "16379"
+    sentinel_cluster_name = "scality-s3"
+    bucketd_host =  "127.0.0.1"
+    bucketd_port = "9000"
+
+
+def safe_print(content):
+    print("{0}".format(content))
+
+
+class updateRedis():
+
+    def __init__(self, ip="127.0.0.1", port="16379", sentinel_cluster_name="scality-s3"):
+
+        r = redis.Redis(host=ip, port=port, db=0)
+        self._ip, self._port = r.sentinel_get_master_addr_by_name(sentinel_cluster_name)
+
+    def read(self, resource, name):
+
+        r = redis.Redis(host=self._ip, port=self._port, db=0)
+        store = r.get('s3:'+resource+':'+name+':storageUtilized:counter')
+        nbr = r.get('s3:'+resource+':'+name+':numberOfObjects:counter')
+        print("Redis:%s:%s:%s" % (name,int(nbr),int(store)))
+
+    def update(self, resource, name, size, files):
+
+        timestamp = int(time.time() - 15 * 60) * 1000
+        r = redis.Redis(host=self._ip, port=self._port, db=0)
+
+        numberOfObjects = 's3:%s:%s:numberOfObjects' % (resource, name)
+        storageUtilized = 's3:%s:%s:storageUtilized' % (resource, name)
+
+        r.zremrangebyscore(numberOfObjects, timestamp, timestamp)
+        r.zremrangebyscore(storageUtilized, timestamp, timestamp)
+        r.zadd(storageUtilized, {size: timestamp})
+        r.zadd(numberOfObjects, {files: timestamp})
+
+        numberOfObjectsCounter = 's3:%s:%s:numberOfObjects:counter' % (
+            resource, name)
+        storageUtilizedCounter = 's3:%s:%s:storageUtilized:counter' % (
+            resource, name)
+        r.set(numberOfObjectsCounter, files)
+        r.set(storageUtilizedCounter, size)
+
+
+class S3ListBuckets():
+
+    def __init__(self, ip="127.0.0.1", bucketd_port="9000"):
+
+        self.ip = ip
+        self.bucketd_port = bucketd_port
+
+    def run(self):
+
+        docs = []
+        url = "http://%s:%s/default/bucket/users..bucket" % (self.ip, self.bucketd_port)
+        session = requests.Session()
+        r = session.get(url, timeout=30)
+        if r.status_code == 200:
+            payload = json.loads(r.text)
+            for keys in payload['Contents']:
+                key = keys["key"]
+                r1 = re.match("(\w+)..\|..(\w+.*)", key)
+                docs.append(r1.groups())
+
+        return docs
+
+
+class S3BucketD(Thread):
+
+    def __init__(self, userid=None, bucket=None, mpu=False, seekeys=False, ip="127.0.0.1", bucketd_port="9000"):
+
+        Thread.__init__(self)
+        self.userid = userid
+        self.bucket = bucket
+        self.mpu = mpu
+        self.files = 0
+        self.total_size = 0
+        if self.mpu:
+            self.bucket = "mpuShadowBucket"+bucket
+        self.seekeys = seekeys
+        self.ip = ip
+        self.bucketd_port = bucketd_port;
+
+    def listbucket(self, session=None, marker=""):
+        m = marker.encode('utf8')
+        mark = urllib.parse.quote_plus(m)
+        params = "%s?listingType=DelimiterMaster&maxKeys=1000&marker=%s" % (
+            self.bucket, mark)
+        url = "http://%s:%s/default/bucket/%s" % (self.ip, self.bucketd_port, params)
+        r = session.get(url, timeout=30)
+        if r.status_code == 200:
+            payload = json.loads(r.text)
+            Contents = payload["Contents"]
+            return (r.status_code, payload, Contents)
+        else:
+            return (r.status_code, "", "")
+
+    def retkeys(self, Contents):
+        total_size = 0
+        files = 0
+        key = ""
+        user = "Unknown"
+        for keys in Contents:
+            key = keys["key"]
+            pfixed = keys["value"].replace('false', 'False')
+            pfixed = pfixed.replace('null', 'None')
+            pfixed = pfixed.replace('true', 'True')
+            data = ast.literal_eval(pfixed)
+            try:
+                total_size += data["content-length"]
+            except:
+                continue
+            files += 1
+            if self.mpu == 0:
+                user = data["owner-display-name"]
+            else:
+                if self.seekeys == 1:
+                    try:
+                        print(data["partLocations"][0]["key"])
+                    except Exception as e:
+                        continue
+                user = "mpu_user"
+        return (key, total_size, user, files)
+
+    def run(self):
+
+        total_size = 0
+        files = 0
+        Truncate = True
+        key = ''
+        while Truncate:
+            while 1:
+                try:
+                    session = requests.Session()
+                    error, payload, Contents = self.listbucket(session, key)
+                    if error == 200:
+                        break
+                    elif error == 404:
+                        sys.exit(1)
+                    time.sleep(15)
+                except Exception as e:
+                    print("ERROR:%s" % e)
+
+            Truncate = payload["IsTruncated"]
+            key, size, user, file = self.retkeys(Contents)
+            total_size += size
+            files += file
+        self.files = files
+        self.user = user
+        self.total_size = total_size
+        content = "%s:%s:%s:%s:%s" % (
+            self.userid, self.bucket, user, files, total_size)
+        executor = ThreadPoolExecutor(max_workers=1)
+        executor.submit(safe_print, content)
+        return(self.userid, self.bucket, user, files, total_size)
+
+
+P = S3ListBuckets(ip=bucketd_host, bucketd_port=bucketd_port)
+listbuckets = P.run()
+
+th = []
+report = {}
+
+for userid, bucket in listbuckets:
+    th.append(S3BucketD(userid=userid, bucket=bucket, ip=bucketd_host, bucketd_port=bucketd_port))
+
+for userid, bucket in listbuckets:
+    th.append(S3BucketD(userid=userid, bucket=bucket, mpu=True, ip=bucketd_host, bucketd_port=bucketd_port))
+
+for i in th:
+    i.start()
+
+for i in th:
+    i.join()
+
+for i in th:
+    U = updateRedis(ip, port, sentinel_cluster_name)
+    U.update('buckets', i.bucket, i.total_size, i.files)
+    usereport = report.get(i.userid, False)
+    if usereport:
+        files = i.files + report[i.userid]["files"]
+        total_size = i.total_size + report[i.userid]["total_size"]
+        report[i.userid] = {"files": files, "total_size": total_size}
+    else:
+        report[i.userid] = {"files": i.files, "total_size": i.total_size}
+
+for rep in report:
+    print("Tool :%s:%s:%s" % (rep,report[rep]['files'],report[rep]['total_size']))
+    U = updateRedis(ip, port, sentinel_cluster_name)
+    U.update('accounts', rep, report[rep]['total_size'], report[rep]['files'])
+    U.read('accounts', rep)


### PR DESCRIPTION
Add the UTAPI reindex feature which queries bucketd for current storage utilized and number of object values, and updates Redis keys accordingly. The operation is performed at a regular interval defined by the user, and set on a default of once per week.

Thank you to @patrickdos for authoring the scripts and providing a solution for the out-of-sync metrics. For python script sources see https://bitbucket.org/scality-ts/utapi-reindex.