### PR TITLE
bugfix: S3C-2076 Update default reindex schedule

### DIFF
--- a/lib/UtapiReindex.js
+++ b/lib/UtapiReindex.js
@@ -9,7 +9,7 @@ const werelogs = require('werelogs');
 const Datastore = require('./Datastore');
 const redisClient = require('../utils/redisClient');
 
-const REINDEX_SCHEDULE = '* * * * * 7';
+const REINDEX_SCHEDULE = '0 0 * * Sun';
 const REINDEX_LOCK_KEY = 's3:utapireindex:lock';
 const REINDEX_LOCK_TTL = (60 * 60) * 24;
 


### PR DESCRIPTION
The crontab is incorrect. It should, by default, run at midnight once per week (i.e. every Sunday).

Note the format is defined [here](https://www.npmjs.com/package/node-schedule#cron-style-scheduling), and differs slightly from the standard crontab format.