### PR TITLE
bugfix: S3C-2019 redis sentinel authentication

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -92,6 +92,12 @@ class Config {
                         'bad config: sentinel port must be a number');
                     this.redis.sentinels.push({ host, port });
                 });
+                if (config.redis.sentinelPassword !== undefined) {
+                    assert(typeof config.redis.sentinelPassword === 'string',
+                        'bad config: redis.sentinelPassword must be a string');
+                    this.redis.sentinelPassword =
+                        config.redis.sentinelPassword;
+                }
             } else {
                 // check for standalone configuration
                 assert(typeof config.redis.host === 'string',

--- a/lib/UtapiReindex.js
+++ b/lib/UtapiReindex.js
@@ -22,6 +22,7 @@ class UtapiReindex {
             host: '127.0.0.1',
             port: 16379,
             name: 'scality-s3',
+            sentinelPassword: '',
         };
         this._bucketd = {
             host: '127.0.0.1',
@@ -36,10 +37,12 @@ class UtapiReindex {
             this._schedule = config.schedule;
         }
         if (config && config.sentinel) {
-            const { host, port, name } = config.sentinel;
+            const { host, port, name, sentinelPassword } = config.sentinel;
             this._sentinel.host = host || this._sentinel.host;
             this._sentinel.port = port || this._sentinel.port;
             this._sentinel.name = name || this._sentinel.name;
+            this._sentinel.sentinelPassword =
+                sentinelPassword || this._sentinel.sentinelPassword;
         }
         if (config && config.bucketd) {
             const { host, port } = config.bucketd;
@@ -61,6 +64,7 @@ class UtapiReindex {
                 port: this._sentinel.port,
             }],
             name: this._sentinel.name,
+            sentinelPassword: this._sentinel.sentinelPassword,
         }, this._log);
     }
 
@@ -78,6 +82,7 @@ class UtapiReindex {
             this._sentinel.host,
             this._sentinel.port,
             this._sentinel.name,
+            this._sentinel.sentinelPassword,
             this._bucketd.host,
             this._bucketd.port,
         ]);

--- a/lib/reindex/reporting.py
+++ b/lib/reindex/reporting.py
@@ -10,12 +10,13 @@ import sys
 from threading import Thread
 from concurrent.futures import ThreadPoolExecutor
 
-if len(sys.argv) == 6:
+if len(sys.argv) == 7:
     ip = sys.argv[1]
     port = sys.argv[2]
     sentinel_cluster_name = sys.argv[3]
-    bucketd_host = sys.argv[4]
-    bucketd_port = sys.argv[5]
+    sentinel_password = sys.argv[4]
+    bucketd_host = sys.argv[5]
+    bucketd_port = sys.argv[6]
     print("Sentinel IP used: %s" % ip)
     print("Sentinel port used: %s" % port)
     print("Sentinel cluster name used: %s" % sentinel_cluster_name)
@@ -25,6 +26,7 @@ else:
     ip = "127.0.0.1"
     port = "16379"
     sentinel_cluster_name = "scality-s3"
+    sentinel_password = ''
     bucketd_host =  "127.0.0.1"
     bucketd_port = "9000"
 
@@ -37,7 +39,7 @@ class askRedis():
 
     def __init__(self, ip="127.0.0.1", port="16379", sentinel_cluster_name="scality-s3"):
 
-        r = redis.Redis(host=ip, port=port, db=0)
+        r = redis.Redis(host=ip, port=port, db=0, password=sentinel_password)
         self._ip, self._port = r.sentinel_get_master_addr_by_name(sentinel_cluster_name)
 
     def read(self, resource, name):

--- a/lib/reindex/s3_bucketd.py
+++ b/lib/reindex/s3_bucketd.py
@@ -10,12 +10,13 @@ import sys
 from threading import Thread
 from concurrent.futures import ThreadPoolExecutor
 
-if len(sys.argv) == 6:
+if len(sys.argv) == 7:
     ip = sys.argv[1]
     port = sys.argv[2]
     sentinel_cluster_name = sys.argv[3]
-    bucketd_host = sys.argv[4]
-    bucketd_port = sys.argv[5]
+    sentinel_password = sys.argv[4]
+    bucketd_host = sys.argv[5]
+    bucketd_port = sys.argv[6]
     print("Sentinel IP used: %s" % ip)
     print("Sentinel port used: %s" % port)
     print("Sentinel cluster name used: %s" % sentinel_cluster_name)
@@ -25,6 +26,7 @@ else:
     ip = "127.0.0.1"
     port = "16379"
     sentinel_cluster_name = "scality-s3"
+    sentinel_password = ''
     bucketd_host =  "127.0.0.1"
     bucketd_port = "9000"
 
@@ -37,7 +39,7 @@ class updateRedis():
 
     def __init__(self, ip="127.0.0.1", port="16379", sentinel_cluster_name="scality-s3"):
 
-        r = redis.Redis(host=ip, port=port, db=0)
+        r = redis.Redis(host=ip, port=port, db=0, password=sentinel_password)
         self._ip, self._port = r.sentinel_get_master_addr_by_name(sentinel_cluster_name)
 
     def read(self, resource, name):

--- a/utils/redisClient.js
+++ b/utils/redisClient.js
@@ -6,6 +6,7 @@ const Redis = require('ioredis');
 * @param {string} config.host - redis host
 * @param {number} config.port - redis port
 * @param {string} [config.password] - redis password (optional)
+* @param {string} [config.sentinelPassword] - sentinel password (optional)
 * @param {Werelogs.Logger} log - Werelogs logger
 * @return {Redis} - Redis client instance
 */


### PR DESCRIPTION
changes in `Config.js` are not needed for S3C-2019 but included for posterity, in case utapi wants a separate config in the future. (Currently config is passed through cloudserver)

Needs further testing, Federation build pointing to this branch can be found here: https://github.com/scality/Federation/pull/2207/commits