### PR TITLE
INTEGRATION [PR#294 > development/8.0] feature: S3C-2260 Add unit and functional testing

### DIFF
--- a/eve/workers/unit_and_feature_tests/Dockerfile
+++ b/eve/workers/unit_and_feature_tests/Dockerfile
@@ -22,5 +22,6 @@ ARG BUILDBOT_VERSION
 
 RUN pip install buildbot-worker==$BUILDBOT_VERSION
 ADD supervisor/buildbot_worker.conf /etc/supervisor/conf.d/
+ADD redis/sentinel.conf /etc/sentinel.conf
 
 CMD ["supervisord", "-n"]

--- a/eve/workers/unit_and_feature_tests/redis/sentinel.conf
+++ b/eve/workers/unit_and_feature_tests/redis/sentinel.conf
@@ -1,0 +1,35 @@
+# Example sentinel.conf
+
+# The port that this sentinel instance will run on
+port 16379
+
+# Specify the log file name. Also the empty string can be used to force
+# Sentinel to log on the standard output. Note that if you use standard
+# output for logging but daemonize, logs will be sent to /dev/null
+logfile ""
+
+# dir <working-directory>
+# Every long running process should have a well-defined working directory.
+# For Redis Sentinel to chdir to /tmp at startup is the simplest thing
+# for the process to don't interfere with administrative tasks such as
+# unmounting filesystems.
+dir /tmp
+
+# sentinel monitor <master-name> <ip> <redis-port> <quorum>
+#
+# Tells Sentinel to monitor this master, and to consider it in O_DOWN
+# (Objectively Down) state only if at least <quorum> sentinels agree.
+#
+# Note that whatever is the ODOWN quorum, a Sentinel will require to
+# be elected by the majority of the known Sentinels in order to
+# start a failover, so no failover can be performed in minority.
+#
+# Replicas are auto-discovered, so you don't need to specify replicas in
+# any way. Sentinel itself will rewrite this configuration file adding
+# the replicas using additional configuration options.
+# Also note that the configuration file is rewritten when a
+# replica is promoted to master.
+#
+# Note: master name should not include special characters or spaces.
+# The valid charset is A-z 0-9 and the three characters ".-_".
+sentinel monitor scality-s3 127.0.0.1 6379 2

--- a/eve/workers/unit_and_feature_tests/redis/sentinel.conf
+++ b/eve/workers/unit_and_feature_tests/redis/sentinel.conf
@@ -32,4 +32,4 @@ dir /tmp
 #
 # Note: master name should not include special characters or spaces.
 # The valid charset is A-z 0-9 and the three characters ".-_".
-sentinel monitor scality-s3 127.0.0.1 6379 2
+sentinel monitor scality-s3 127.0.0.1 6379 1

--- a/eve/workers/unit_and_feature_tests/supervisor/buildbot_worker.conf
+++ b/eve/workers/unit_and_feature_tests/supervisor/buildbot_worker.conf
@@ -3,7 +3,12 @@ command=/bin/sh -c 'buildbot-worker create-worker . "%(ENV_BUILDMASTER)s:%(ENV_B
 autostart=true
 autorestart=false
 
-[program:redis]
+[program:redis_server]
 command=/usr/bin/redis-server
+autostart=true
+autorestart=false
+
+[program:redis_sentinel]
+command=/usr/bin/redis-server /etc/sentinel.conf --sentinel
 autostart=true
 autorestart=false

--- a/tests/functional/testReindex.js
+++ b/tests/functional/testReindex.js
@@ -1,0 +1,64 @@
+const assert = require('assert');
+
+const UtapiReindex = require('../../lib/UtapiReindex');
+const redisClient = require('../../utils/redisClient');
+const log = require('../utils/mock/log');
+
+describe('UtapiReindex', () => {
+    let reindex;
+    let redis;
+
+    beforeEach(done => {
+        reindex = new UtapiReindex();
+        redis = redisClient({}, log)
+            .on('ready', done)
+            .on('error', done);
+    });
+
+    afterEach(done => {
+        redis.flushdb(done);
+    });
+
+    describe('::_connect', () => {
+        it('should connect to the redis sentinel', done => {
+            reindex._connect(done);
+        });
+    });
+
+    describe('::_lock', () => {
+        beforeEach(done => {
+            reindex._connect(done);
+        });
+
+        describe('lock is not acquired', () => {
+            it('should acquire the lock key', done => {
+                reindex._lock()
+                    .then(res => {
+                        assert.strictEqual(res, 'OK');
+                    })
+                    .then(done)
+                    .catch(done);
+            });
+        });
+
+        describe('lock is already acquired', () => {
+            beforeEach(done => {
+                reindex._lock()
+                    .then(res => {
+                        assert.strictEqual(res, 'OK');
+                    })
+                    .then(done)
+                    .catch(done);
+            });
+
+            it('should not acquire the lock key', done => {
+                reindex._lock()
+                    .then(res => {
+                        assert.strictEqual(res, null);
+                    })
+                    .then(done)
+                    .catch(done);
+            });
+        });
+    });
+});

--- a/tests/functional/testReindex.js
+++ b/tests/functional/testReindex.js
@@ -4,7 +4,7 @@ const UtapiReindex = require('../../lib/UtapiReindex');
 const redisClient = require('../../utils/redisClient');
 const log = require('../utils/mock/log');
 
-describe('UtapiReindex', () => {
+describe.only('UtapiReindex', () => {
     let reindex;
     let redis;
 
@@ -16,7 +16,12 @@ describe('UtapiReindex', () => {
     });
 
     afterEach(done => {
-        redis.flushdb(done);
+        redis
+            .on('close', done)
+            .on('error', done)
+            .flushdb()
+            .then(() => redis.quit())
+            .catch(done);
     });
 
     describe('::_connect', () => {

--- a/tests/utils/mock/log.js
+++ b/tests/utils/mock/log.js
@@ -1,0 +1,10 @@
+const log = {
+    trace: () => {},
+    error: () => {},
+    info: () => {},
+    debug: () => {},
+    getSerializedUids: () => {},
+    end: () => {},
+};
+
+module.exports = log;


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #294.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.0/feature/S3C-2260-maintenance-testing-for-utapi-reindexer`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.0/feature/S3C-2260-maintenance-testing-for-utapi-reindexer
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.0/feature/S3C-2260-maintenance-testing-for-utapi-reindexer
```

Please always comment pull request #294 instead of this one.