### PR TITLE
bugfix: S3C-2322 UtapiClient configuration update

### DIFF
--- a/lib/UtapiClient.js
+++ b/lib/UtapiClient.js
@@ -114,7 +114,7 @@ class UtapiClient {
             }
             this.disableClient = false;
             this.expireMetrics = config.expireMetrics;
-            this.expireTTL = config.expireTTL || 0;
+            this.expireMetricsTTL = config.expireMetricsTTL || 0;
         }
     }
 
@@ -434,7 +434,7 @@ class UtapiClient {
 
     _expireMetrics(keys, log, callback) {
         // expire metrics here
-        const expireCmds = keys.map(k => ['expire', k, this.expireTTL]);
+        const expireCmds = keys.map(k => ['expire', k, this.expireMetricsTTL]);
         return this.ds.multi(expireCmds, (err, result) => {
             if (err) {
                 const logParam = Array.isArray(err) ? { errorList: err } :


### PR DESCRIPTION
Update UtapiClient to use correct expire metrics TTL config field.

**Summary**

The field `expireMetricsTTL` is set in the CloudServer configuration by Federation [here](https://github.com/scality/Federation/blob/a457d7f2578249dba4ac585bbe6b21bc04f48590/roles/run-s3/templates/config.json.j2#L72). It is then set for the Utapi client configuration in CloudServer [here](https://github.com/scality/cloudserver/blob/development/8.1/lib/Config.js#L1010). In the UtapiClient instance, I would expect the field `expireMetricsTTL` to be used. Instead another field `expireTTL` is used [here](https://github.com/scality/utapi/blob/development/8.0/lib/UtapiClient.js#L97). 

The result is that the expire TTL always defaults to 0, even if another TTL is set in the configuration.