### PR TITLE
bugfix: S3C-2317 Add uuid module as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "async": "^2.0.1",
     "ioredis": "^4.9.5",
     "node-schedule": "1.2.0",
+    "uuid": "^3.3.2",
     "vaultclient": "scality/vaultclient#3eaaff2",
     "werelogs": "scality/werelogs#4e0d97c"
   },


### PR DESCRIPTION
The `uuid` module is already installed by another dependency. However UTAPI requires this module so it is best practice to add it as a dependency in the `package.json`.