### PR TITLE
improvement S3C-234 Operation counters config

### DIFF
--- a/lib/UtapiClient.js
+++ b/lib/UtapiClient.js
@@ -89,6 +89,8 @@ class UtapiClient {
         // By default, we push all resource types
         this.metrics = ['buckets', 'accounts', 'users', 'service'];
         this.service = 's3';
+        this.disableOperationCounters = false;
+        this.enabledOperationCounters = [];
         this.disableClient = true;
 
         if (config) {
@@ -112,6 +114,12 @@ class UtapiClient {
                 // The configuration uses the property `component`, while
                 // internally this is known as a metric level `service`.
                 this.service = config.component;
+            }
+            if (config.disableOperationCounters) {
+                this.disableOperationCounters = config.disableOperationCounters;
+            }
+            if (config.enabledOperationCounters) {
+                this.enabledOperationCounters = config.enabledOperationCounters;
             }
             this.disableClient = false;
             this.expireMetrics = config.expireMetrics;
@@ -143,6 +151,14 @@ class UtapiClient {
         this.ds = ds;
         this.disableClient = false;
         return this;
+    }
+
+    _isCounterEnabled(action) {
+        if (this.enabledOperationCounters.length > 0) {
+            return this.enabledOperationCounters.some(counter =>
+                counter.toLowerCase() === action.toLowerCase());
+        }
+        return this.disableOperationCounters === false;
     }
 
     /*
@@ -377,6 +393,9 @@ class UtapiClient {
     * @return {undefined}
     */
     _genericPushMetric(params, timestamp, action, log, callback) {
+        if (!this._isCounterEnabled(action)) {
+            return process.nextTick(callback);
+        }
         this._checkProperties(params);
         this._logMetric(params, '_genericPushMetric', timestamp, log);
         const cmds = this._getParamsArr(params)
@@ -480,12 +499,12 @@ class UtapiClient {
             log);
         const cmds = [];
         const paramsArr = this._getParamsArr(params);
-        paramsArr.forEach(p => cmds.push(
-            ['incr', generateCounter(p, 'numberOfObjectsCounter')],
-            ['incr', generateKey(p, 'deleteObject', timestamp)]));
-        // We track the number of commands needed for each `paramsArr` property
-        // to eventually locate each group in the results from Redis.
-        const commandsGroupSize = 2;
+        paramsArr.forEach(p => {
+            cmds.push(['incr', generateCounter(p, 'numberOfObjectsCounter')]);
+            if (this._isCounterEnabled('deleteObject')) {
+                cmds.push(['incr', generateKey(p, 'deleteObject', timestamp)]);
+            }
+        });
         return this.ds.batch(cmds, (err, results) => {
             if (err) {
                 log.error('error pushing metric', {
@@ -495,9 +514,13 @@ class UtapiClient {
                 return this._pushLocalCache(params, action, timestamp, log, cb);
             }
             const cmds2 = [];
+            // We track the number of commands needed for each `paramsArr`
+            // property to eventually locate each group in the results from
+            // Redis.
+            const commandsGroupSize = (cmds.length / paramsArr.length);
             const noErr = paramsArr.every((p, i) => {
-                // We want the first element of every group of two commands
-                // returned from Redis. This contains the value of the
+                // We want the first element of every group of commands returned
+                // from Redis. This contains the value of the
                 // numberOfObjectsCounter after it has been incremented.
                 const index = i * commandsGroupSize;
                 const actionErr = results[index][0];
@@ -553,9 +576,11 @@ class UtapiClient {
                 ['incrby', generateCounter(p, 'storageUtilizedCounter'),
                     storageUtilizedDelta],
                 ['incrby', generateKey(p, 'incomingBytes', timestamp),
-                    newByteLength],
-                ['incr', generateKey(p, action, timestamp)]
+                    newByteLength]
             );
+            if (this._isCounterEnabled(action)) {
+                cmds.push(['incr', generateKey(p, action, timestamp)]);
+            }
         });
         // update counters
         return this.ds.batch(cmds, (err, results) => {
@@ -628,14 +653,14 @@ class UtapiClient {
         const paramsArr = this._getParamsArr(params);
         const cmds = [];
         paramsArr.forEach(p => {
-            cmds.push(
-                ['incr', generateCounter(p, 'numberOfObjectsCounter')],
-                ['incr', generateKey(p, action, timestamp)]
-            );
+            cmds.push(['incr', generateCounter(p, 'numberOfObjectsCounter')]);
+            if (this._isCounterEnabled(action)) {
+                cmds.push(['incr', generateKey(p, action, timestamp)]);
+            }
         });
         // We track the number of commands needed for each `paramsArr` object to
         // eventually locate each group in the results from Redis.
-        const commandsGroupSize = 2;
+        const commandsGroupSize = (cmds.length / paramsArr.length);
         return this.ds.batch(cmds, (err, results) => {
             if (err) {
                 log.error('error incrementing counter for push metric', {
@@ -727,9 +752,11 @@ class UtapiClient {
         paramsArr.forEach(p => {
             cmds.push(
                 ['decrby', generateCounter(p, 'storageUtilizedCounter'),
-                    byteLength],
-                ['incr', generateKey(p, action, timestamp)]
+                    byteLength]
             );
+            if (this._isCounterEnabled(action)) {
+                cmds.push(['incr', generateKey(p, action, timestamp)]);
+            }
             // The 'abortMultipartUpload' action affects only storage utilized,
             // so number of objects remains unchanged.
             if (action !== 'abortMultipartUpload') {
@@ -739,7 +766,7 @@ class UtapiClient {
         });
         // We track the number of commands needed for each `paramsArr` object to
         // eventually locate each group in the results from Redis.
-        const commandsGroupSize = action !== 'abortMultipartUpload' ? 3 : 2;
+        const commandsGroupSize = (cmds.length / paramsArr.length);
         return this.ds.batch(cmds, (err, results) => {
             if (err) {
                 log.error('error incrementing counter', {
@@ -790,9 +817,10 @@ class UtapiClient {
                 if (action === 'abortMultipartUpload') {
                     return true;
                 }
-                // The number of objects counter result is the third element of
-                // each group of commands. Thus we add two.
-                const numberOfObjectsResult = currentResultsGroup + 2;
+                // The number of objects counter result is the last element of
+                // each group of commands.
+                const numberOfObjectsResult =
+                    currentResultsGroup + (commandsGroupSize - 1);
                 actionErr = results[numberOfObjectsResult][0];
                 actionCounter = parseInt(results[numberOfObjectsResult][1], 10);
                 // If < 0, record numberOfObjects as though bucket were empty.
@@ -845,9 +873,11 @@ class UtapiClient {
         paramsArr.forEach(p => {
             cmds.push(
                 ['incrby', generateKey(p, 'outgoingBytes', timestamp),
-                    newByteLength],
-                ['incr', generateKey(p, action, timestamp)]
+                    newByteLength]
             );
+            if (this._isCounterEnabled(action)) {
+                cmds.push(['incr', generateKey(p, action, timestamp)]);
+            }
         });
         // update counters
         return this.ds.batch(cmds, err => {
@@ -895,7 +925,7 @@ class UtapiClient {
                     storageUtilizedDelta],
                 [redisCmd, generateCounter(p, 'numberOfObjectsCounter')]
             );
-            if (action !== 'putData') {
+            if (action !== 'putData' && this._isCounterEnabled(action)) {
                 cmds.push(['incr', generateKey(p, action, timestamp)]);
             }
             if (action === 'putObject' || action === 'putData') {

--- a/tests/unit/testUtapiClient.js
+++ b/tests/unit/testUtapiClient.js
@@ -78,42 +78,6 @@ function setMockData(data, timestamp, cb) {
     return cb();
 }
 
-// Get the expected object for comparison
-function getObject(timestamp, data) {
-    const obj = {};
-    const prefixValuesArr = getPrefixValues(timestamp);
-    prefixValuesArr.forEach(type => {
-        const { key, timestampKey } = type;
-        if (data.action) {
-            // The action is always incremented to one in the tests
-            obj[`${timestampKey}:${data.action}`] = '1';
-        }
-        // The expected object is constructed based on the `data` object
-        Object.keys(data).forEach(metric => {
-            if (metric === 'storageUtilized') {
-                obj[`${key}:storageUtilized:counter`] = data[metric];
-                obj[`${key}:storageUtilized`] = [[timestamp, data[metric]]];
-            } else if (metric === 'numberOfObjects') {
-                obj[`${key}:numberOfObjects:counter`] = data[metric];
-                obj[`${key}:numberOfObjects`] = [[timestamp, data[metric]]];
-            } else if (metric !== 'action') {
-                obj[`${timestampKey}:${metric}`] = data[metric];
-            }
-        });
-    });
-    return obj;
-}
-
-function testMetric(metric, params, expected, cb) {
-    const c = new UtapiClient(config);
-    c.setDataStore(ds);
-    c.pushMetric(metric, REQUID, params, () => {
-        deserializeMemoryBackend(memoryBackend.data);
-        assert.deepStrictEqual(memoryBackend.data, expected);
-        return cb();
-    });
-}
-
 describe('UtapiClient:: enable/disable client', () => {
     it('should disable client when no redis config is provided', () => {
         const c = new UtapiClient();
@@ -132,392 +96,584 @@ describe('UtapiClient:: enable/disable client', () => {
     });
 });
 
-describe('UtapiClient:: push metrics', () => {
+describe('UtapiClient:: _isCounterEnabled', () => {
+    const metric = 'putObject';
+
+    it('should return true when disableOperationCounters and ' +
+    'enabledOperationCounters are not provided in config', () => {
+        const client = new UtapiClient();
+        const result = client._isCounterEnabled(metric);
+        assert.strictEqual(result, true);
+    });
+
+    it('should return false when disableOperationCounters is true', () => {
+        const client = new UtapiClient({
+            disableOperationCounters: true,
+        });
+        const result = client._isCounterEnabled(metric);
+        assert.strictEqual(result, false);
+    });
+
+    describe('when enabledOperationCounters is provided in config', () => {
+        it('should return false wmetric is not in the list', () => {
+            const client = new UtapiClient({
+                enabledOperationCounters: ['createBucket'],
+            });
+            const result = client._isCounterEnabled(metric);
+            assert.strictEqual(result, false);
+        });
+
+        it('should return true when metric is in the list', () => {
+            const client = new UtapiClient({
+                enabledOperationCounters: [metric],
+            });
+            const result = client._isCounterEnabled(metric);
+            assert.strictEqual(result, true);
+        });
+    });
+});
+
+const tests = [
+    {
+        description: 'with no custom configuration',
+        configuration: {},
+    },
+    {
+        description: 'when disableOperationCounters is true',
+        configuration: {
+            disableOperationCounters: true,
+        },
+    },
+    {
+        description: 'when enabledOperationCounters is missing the counter',
+        configuration: {
+            enabledOperationCounters: [''],
+        },
+    },
+    {
+        description: 'when enabledOperationCounters includes the counter',
+        configuration: {
+            enabledOperationCounters: [
+                'DeleteBucket',
+                'DeleteBucketCors',
+                'DeleteBucketWebsite',
+                'DeleteObjectTagging',
+                'ListBucket',
+                'GetBucketAcl',
+                'GetBucketCors',
+                'GetBucketWebsite',
+                'GetBucketLocation',
+                'CreateBucket',
+                'PutBucketAcl',
+                'PutBucketCors',
+                'PutBucketWebsite',
+                'PutObject',
+                'CopyObject',
+                'UploadPart',
+                'UploadPartCopy',
+                'ListBucketMultipartUploads',
+                'ListMultipartUploadParts',
+                'InitiateMultipartUpload',
+                'CompleteMultipartUpload',
+                'AbortMultipartUpload',
+                'DeleteObject',
+                'MultiObjectDelete',
+                'GetObject',
+                'GetObjectAcl',
+                'GetObjectTagging',
+                'PutObjectAcl',
+                'PutObjectTagging',
+                'HeadBucket',
+                'HeadObject',
+                'PutBucketVersioning',
+                'GetBucketVersioning',
+                'PutBucketReplication',
+                'GetBucketReplication',
+                'DeleteBucketReplication',
+            ],
+        },
+    },
+];
+
+tests.forEach(test => {
+    const { configuration, description } = test;
+
     const timestamp = getNormalizedTimestamp(Date.now());
-    let params;
 
-    beforeEach(() => {
-        params = {
-            byteLength: undefined,
-            newByteLength: undefined,
-            oldByteLength: undefined,
-            numberOfObjects: undefined,
-        };
-    });
+    function shouldIncludeCounter(action) {
+        const enabledOperationCounters = configuration.enabledOperationCounters;
+        if (enabledOperationCounters && enabledOperationCounters.length > 0) {
+            return enabledOperationCounters.some(
+                counter => counter.toLowerCase() === action.toLowerCase());
+        }
+        return !configuration.disableOperationCounters;
+    }
 
-    afterEach(() => memoryBackend.flushDb());
-
-    it('should push createBucket metrics', done => {
-        const expected = getObject(timestamp, { action: 'CreateBucket' });
-        testMetric('createBucket', metricTypes, expected, done);
-    });
-
-    it('should push deleteBucket metrics', done => {
-        const expected = getObject(timestamp, { action: 'DeleteBucket' });
-        testMetric('deleteBucket', metricTypes, expected, done);
-    });
-
-    it('should push listBucket metrics', done => {
-        const expected = getObject(timestamp, { action: 'ListBucket' });
-        testMetric('listBucket', metricTypes, expected, done);
-    });
-
-    it('should push getBucketAcl metrics', done => {
-        const expected = getObject(timestamp, { action: 'GetBucketAcl' });
-        testMetric('getBucketAcl', metricTypes, expected, done);
-    });
-
-    it('should push putBucketAcl metrics', done => {
-        const expected = getObject(timestamp, { action: 'PutBucketAcl' });
-        testMetric('putBucketAcl', metricTypes, expected, done);
-    });
-
-    it('should push putBucketCors metrics', done => {
-        const expected = getObject(timestamp, { action: 'PutBucketCors' });
-        testMetric('putBucketCors', metricTypes, expected, done);
-    });
-
-    it('should push getBucketCors metrics', done => {
-        const expected = getObject(timestamp, { action: 'GetBucketCors' });
-        testMetric('getBucketCors', metricTypes, expected, done);
-    });
-
-    it('should push deleteBucketCors metrics', done => {
-        const expected = getObject(timestamp,
-            { action: 'DeleteBucketCors' });
-        testMetric('deleteBucketCors', metricTypes, expected, done);
-    });
-
-    it('should push putBucketWebsite metrics', done => {
-        const expected = getObject(timestamp, { action: 'PutBucketWebsite' });
-        testMetric('putBucketWebsite', metricTypes, expected, done);
-    });
-
-    it('should push getBucketWebsite metrics', done => {
-        const expected = getObject(timestamp, { action: 'GetBucketWebsite' });
-        testMetric('getBucketWebsite', metricTypes, expected, done);
-    });
-
-    it('should push getBucketLocation metrics', done => {
-        const expected = getObject(timestamp, { action: 'GetBucketLocation' });
-        testMetric('getBucketLocation', metricTypes, expected, done);
-    });
-
-    it('should push deleteBucketWebsite metrics', done => {
-        const expected = getObject(timestamp,
-            { action: 'DeleteBucketWebsite' });
-        testMetric('deleteBucketWebsite', metricTypes, expected, done);
-    });
-
-    it('should push uploadPart metrics', done => {
-        const expected = getObject(timestamp, {
-            action: 'UploadPart',
-            storageUtilized: '1024',
-            incomingBytes: '1024',
+    // Get the expected object for comparison
+    function buildExpectedResult(data) {
+        const obj = {};
+        const prefixValuesArr = getPrefixValues(timestamp);
+        prefixValuesArr.forEach(type => {
+            const { key, timestampKey } = type;
+            if (data.action && shouldIncludeCounter(data.action)) {
+                obj[`${timestampKey}:${data.action}`] = '1';
+            }
+            // The expected object is constructed based on the `data` object
+            Object.keys(data).forEach(metric => {
+                if (metric === 'storageUtilized') {
+                    obj[`${key}:storageUtilized:counter`] = data[metric];
+                    obj[`${key}:storageUtilized`] = [[timestamp, data[metric]]];
+                } else if (metric === 'numberOfObjects') {
+                    obj[`${key}:numberOfObjects:counter`] = data[metric];
+                    obj[`${key}:numberOfObjects`] = [[timestamp, data[metric]]];
+                } else if (metric !== 'action') {
+                    obj[`${timestampKey}:${metric}`] = data[metric];
+                }
+            });
         });
-        Object.assign(params, metricTypes, {
-            newByteLength: 1024,
-            oldByteLength: null,
-        });
-        testMetric('uploadPart', params, expected, done);
-    });
+        return obj;
+    }
 
-    it('should push metric for uploadPart overwrite', done => {
-        const expected = getObject(timestamp, {
-            action: 'UploadPart',
-            storageUtilized: '1024',
-            incomingBytes: '1024',
+    function testMetric(metric, params, expected, cb) {
+        const c = new UtapiClient(Object.assign({}, config, configuration));
+        c.setDataStore(ds);
+        c.pushMetric(metric, REQUID, params, () => {
+            deserializeMemoryBackend(memoryBackend.data);
+            assert.deepStrictEqual(memoryBackend.data, expected);
+            return cb();
         });
-        Object.assign(params, metricTypes, {
-            newByteLength: 1024,
-            oldByteLength: 2048,
+    }
+
+    describe(`UtapiClient:: push metrics ${description}`, () => {
+        let params;
+
+        beforeEach(() => {
+            params = {
+                byteLength: undefined,
+                newByteLength: undefined,
+                oldByteLength: undefined,
+                numberOfObjects: undefined,
+            };
         });
-        const data = { storageUtilized: '2048' };
-        setMockData(data, timestamp, () =>
-            testMetric('uploadPart', params, expected, done));
-    });
 
-    it('should push uploadPartCopy metrics', done => {
-        const expected = getObject(timestamp, {
-            action: 'UploadPartCopy',
-            storageUtilized: '1024',
-            incomingBytes: '1024',
+        afterEach(() => memoryBackend.flushDb());
+
+        it('should push createBucket metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'CreateBucket',
+            });
+            testMetric('createBucket', metricTypes, expected, done);
         });
-        Object.assign(params, metricTypes, {
-            newByteLength: 1024,
-            oldByteLength: null,
+
+        it('should push deleteBucket metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'DeleteBucket',
+            });
+            testMetric('deleteBucket', metricTypes, expected, done);
         });
-        testMetric('uploadPartCopy', params, expected, done);
-    });
 
-    it('should push metric for uploadPartCopy overwrite', done => {
-        const expected = getObject(timestamp, {
-            action: 'UploadPartCopy',
-            storageUtilized: '1024',
-            incomingBytes: '1024',
+        it('should push listBucket metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'ListBucket',
+            });
+            testMetric('listBucket', metricTypes, expected, done);
         });
-        Object.assign(params, metricTypes, {
-            newByteLength: 1024,
-            oldByteLength: 2048,
+
+        it('should push getBucketAcl metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'GetBucketAcl',
+            });
+            testMetric('getBucketAcl', metricTypes, expected, done);
         });
-        const data = { storageUtilized: '2048' };
-        setMockData(data, timestamp, () =>
-            testMetric('uploadPartCopy', params, expected, done));
-    });
 
-    it('should push initiateMultipartUpload metrics', done => {
-        const expected = getObject(timestamp,
-            { action: 'InitiateMultipartUpload' });
-        testMetric('initiateMultipartUpload', metricTypes, expected, done);
-    });
-
-    it('should push completeMultipartUpload metrics', done => {
-        const expected = getObject(timestamp, {
-            action: 'CompleteMultipartUpload',
-            numberOfObjects: '1',
+        it('should push putBucketAcl metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'PutBucketAcl',
+            });
+            testMetric('putBucketAcl', metricTypes, expected, done);
         });
-        testMetric('completeMultipartUpload', metricTypes, expected, done);
-    });
 
-    it('should push listMultipartUploads metrics', done => {
-        const expected = getObject(timestamp,
-            { action: 'ListBucketMultipartUploads' });
-        testMetric('listMultipartUploads', metricTypes, expected, done);
-    });
-
-    it('should push listMultipartUploadParts metrics', done => {
-        const expected = getObject(timestamp,
-            { action: 'ListMultipartUploadParts' });
-        testMetric('listMultipartUploadParts', metricTypes, expected, done);
-    });
-
-    it('should push abortMultipartUpload metrics', done => {
-        const expected = getObject(timestamp, {
-            action: 'AbortMultipartUpload',
-            storageUtilized: '0',
+        it('should push putBucketCors metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'PutBucketCors',
+            });
+            testMetric('putBucketCors', metricTypes, expected, done);
         });
-        Object.assign(params, metricTypes, { byteLength: 1024 });
-        // Set mock data of one, 1024 byte part object for
-        // `AbortMultipartUpload` to update.
-        const data = { storageUtilized: '1024' };
-        setMockData(data, timestamp, () =>
-            testMetric('abortMultipartUpload', params, expected, done));
-    });
 
-    it('should push deleteObject metrics', done => {
-        const expected = getObject(timestamp, {
-            action: 'DeleteObject',
-            storageUtilized: '0',
-            numberOfObjects: '0',
+        it('should push getBucketCors metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'GetBucketCors',
+            });
+            testMetric('getBucketCors', metricTypes, expected, done);
         });
-        Object.assign(params, metricTypes, {
-            byteLength: 1024,
-            numberOfObjects: 1,
+
+        it('should push deleteBucketCors metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'DeleteBucketCors',
+            });
+            testMetric('deleteBucketCors', metricTypes, expected, done);
         });
-        // Set mock data of one, 1024 byte object for `deleteObject` to update.
-        const data = {
-            storageUtilized: '1024',
-            numberOfObjects: '1',
-        };
-        setMockData(data, timestamp, () =>
-            testMetric('deleteObject', params, expected, done));
-    });
 
-    it('should push multiObjectDelete metrics', done => {
-        const expected = getObject(timestamp, {
-            action: 'MultiObjectDelete',
-            storageUtilized: '0',
-            numberOfObjects: '0',
+        it('should push putBucketWebsite metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'PutBucketWebsite',
+            });
+            testMetric('putBucketWebsite', metricTypes, expected, done);
         });
-        Object.assign(params, metricTypes, {
-            byteLength: 2048,
-            numberOfObjects: 2,
+
+        it('should push getBucketWebsite metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'GetBucketWebsite',
+            });
+            testMetric('getBucketWebsite', metricTypes, expected, done);
         });
-        // Set mock data of two, 1024 byte objects for `multiObjectDelete`
-        // to update.
-        const data = {
-            storageUtilized: '2048',
-            numberOfObjects: '2',
-        };
-        setMockData(data, timestamp, () =>
-            testMetric('multiObjectDelete', params, expected, done));
-    });
 
-    it('should push getObject metrics', done => {
-        const expected = getObject(timestamp, {
-            action: 'GetObject',
-            outgoingBytes: '1024',
+        it('should push getBucketLocation metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'GetBucketLocation',
+            });
+            testMetric('getBucketLocation', metricTypes, expected, done);
         });
-        Object.assign(params, metricTypes, { newByteLength: 1024 });
-        testMetric('getObject', params, expected, done);
-    });
 
-    it('should push getObjectAcl metrics', done => {
-        const expected = getObject(timestamp,
-            { action: 'GetObjectAcl' });
-        testMetric('getObjectAcl', metricTypes, expected, done);
-    });
-
-    it('should push getObjectTagging metrics', done => {
-        const expected = getObject(timestamp,
-            { action: 'GetObjectTagging' });
-        testMetric('getObjectTagging', metricTypes, expected, done);
-    });
-
-    it('should push putObject metrics', done => {
-        const expected = getObject(timestamp, {
-            action: 'PutObject',
-            storageUtilized: '1024',
-            numberOfObjects: '1',
-            incomingBytes: '1024',
+        it('should push deleteBucketWebsite metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'DeleteBucketWebsite',
+            });
+            testMetric('deleteBucketWebsite', metricTypes, expected, done);
         });
-        Object.assign(params, metricTypes, {
-            newByteLength: 1024,
-            oldByteLength: null,
+
+        it('should push uploadPart metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'UploadPart',
+                storageUtilized: '1024',
+                incomingBytes: '1024',
+            });
+            Object.assign(params, metricTypes, {
+                newByteLength: 1024,
+                oldByteLength: null,
+            });
+            testMetric('uploadPart', params, expected, done);
         });
-        testMetric('putObject', params, expected, done);
-    });
 
-    it('should push putObject overwrite metrics', done => {
-        const expected = getObject(timestamp, {
-            action: 'PutObject',
-            storageUtilized: '2048',
-            numberOfObjects: '1',
-            incomingBytes: '2048',
+        it('should push metric for uploadPart overwrite', done => {
+            const expected = buildExpectedResult({
+                action: 'UploadPart',
+                storageUtilized: '1024',
+                incomingBytes: '1024',
+            });
+            Object.assign(params, metricTypes, {
+                newByteLength: 1024,
+                oldByteLength: 2048,
+            });
+            const data = { storageUtilized: '2048' };
+            setMockData(data, timestamp, () => {
+                testMetric('uploadPart', params, expected, done);
+            });
         });
-        Object.assign(params, metricTypes, {
-            newByteLength: 2048,
-            oldByteLength: 1024,
+
+        it('should push uploadPartCopy metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'UploadPartCopy',
+                storageUtilized: '1024',
+                incomingBytes: '1024',
+            });
+            Object.assign(params, metricTypes, {
+                newByteLength: 1024,
+                oldByteLength: null,
+            });
+            testMetric('uploadPartCopy', params, expected, done);
         });
-        // Set mock data of one, 1024 byte object for `putObject` to
-        // overwrite. Counter does not increment because it is an overwrite.
-        const data = {
-            storageUtilized: '1024',
-            numberOfObjects: '1',
-        };
-        setMockData(data, timestamp, () =>
-            testMetric('putObject', params, expected, done));
-    });
 
-    it('should push copyObject metrics', done => {
-        const expected = getObject(timestamp, {
-            action: 'CopyObject',
-            storageUtilized: '1024',
-            numberOfObjects: '1',
+        it('should push metric for uploadPartCopy overwrite', done => {
+            const expected = buildExpectedResult({
+                action: 'UploadPartCopy',
+                storageUtilized: '1024',
+                incomingBytes: '1024',
+            });
+            Object.assign(params, metricTypes, {
+                newByteLength: 1024,
+                oldByteLength: 2048,
+            });
+            const data = { storageUtilized: '2048' };
+            setMockData(data, timestamp, () => {
+                testMetric('uploadPartCopy', params, expected, done);
+            });
         });
-        Object.assign(params, metricTypes, {
-            newByteLength: 1024,
-            oldByteLength: null,
+
+        it('should push initiateMultipartUpload metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'InitiateMultipartUpload',
+            });
+            testMetric('initiateMultipartUpload', metricTypes, expected, done);
         });
-        testMetric('copyObject', params, expected, done);
-    });
 
-    it('should push copyObject overwrite metrics', done => {
-        const expected = getObject(timestamp, {
-            action: 'CopyObject',
-            storageUtilized: '2048',
-            numberOfObjects: '1',
+        it('should push completeMultipartUpload metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'CompleteMultipartUpload',
+                numberOfObjects: '1',
+            });
+            testMetric('completeMultipartUpload', metricTypes, expected, done);
         });
-        Object.assign(params, metricTypes, {
-            newByteLength: 2048,
-            oldByteLength: 1024,
+
+        it('should push listMultipartUploads metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'ListBucketMultipartUploads',
+            });
+            testMetric('listMultipartUploads', metricTypes, expected, done);
         });
-        // Set mock data of one, 1024 byte object for `copyObject` to
-        // overwrite. Counter does not increment because it is an overwrite.
-        const data = {
-            storageUtilized: '1024',
-            numberOfObjects: '1',
-        };
-        setMockData(data, timestamp, () =>
-            testMetric('copyObject', params, expected, done));
-    });
 
-    it('should push putData metrics', done => {
-        const expected = getObject(timestamp, {
-            storageUtilized: '1024',
-            numberOfObjects: '1',
-            incomingBytes: '1024',
+        it('should push listMultipartUploadParts metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'ListMultipartUploadParts',
+            });
+            testMetric('listMultipartUploadParts', metricTypes, expected, done);
         });
-        Object.assign(params, metricTypes, {
-            newByteLength: 1024,
-            oldByteLength: null,
+
+        it('should push abortMultipartUpload metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'AbortMultipartUpload',
+                storageUtilized: '0',
+            });
+            Object.assign(params, metricTypes, { byteLength: 1024 });
+            // Set mock data of one, 1024 byte part object for
+            // `AbortMultipartUpload` to update.
+            const data = { storageUtilized: '1024' };
+            setMockData(data, timestamp, () => {
+                testMetric('abortMultipartUpload', params, expected, done);
+            });
         });
-        testMetric('putData', params, expected, done);
-    });
 
-    it('should push putObjectAcl metrics', done => {
-        const expected = getObject(timestamp, { action: 'PutObjectAcl' });
-        testMetric('putObjectAcl', metricTypes, expected, done);
-    });
-
-    it('should push putObjectTagging metrics', done => {
-        const expected = getObject(timestamp, { action: 'PutObjectTagging' });
-        testMetric('putObjectTagging', metricTypes, expected, done);
-    });
-
-    it('should push deleteObjectTagging metrics', done => {
-        const expected = getObject(timestamp, { action:
-          'DeleteObjectTagging' });
-        testMetric('deleteObjectTagging', metricTypes, expected, done);
-    });
-
-    it('should push headBucket metrics', done => {
-        const expected = getObject(timestamp, { action: 'HeadBucket' });
-        testMetric('headBucket', metricTypes, expected, done);
-    });
-
-    it('should push headObject metrics', done => {
-        const expected = getObject(timestamp, { action: 'HeadObject' });
-        testMetric('headObject', metricTypes, expected, done);
-    });
-
-    it('should push putBucketVersioning metrics', done => {
-        const expected = getObject(timestamp, {
-            action: 'PutBucketVersioning',
+        it('should push deleteObject metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'DeleteObject',
+                storageUtilized: '0',
+                numberOfObjects: '0',
+            });
+            Object.assign(params, metricTypes, {
+                byteLength: 1024,
+                numberOfObjects: 1,
+            });
+            // Set mock data of one, 1024 byte object for `deleteObject` to
+            // update.
+            const data = {
+                storageUtilized: '1024',
+                numberOfObjects: '1',
+            };
+            setMockData(data, timestamp, () => {
+                testMetric('deleteObject', params, expected, done);
+            });
         });
-        testMetric('putBucketVersioning', metricTypes, expected, done);
-    });
 
-    it('should push getBucketVersioning metrics', done => {
-        const expected = getObject(timestamp, {
-            action: 'GetBucketVersioning',
+        it('should push multiObjectDelete metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'MultiObjectDelete',
+                storageUtilized: '0',
+                numberOfObjects: '0',
+            });
+            Object.assign(params, metricTypes, {
+                byteLength: 2048,
+                numberOfObjects: 2,
+            });
+            // Set mock data of two, 1024 byte objects for `multiObjectDelete`
+            // to update.
+            const data = {
+                storageUtilized: '2048',
+                numberOfObjects: '2',
+            };
+            setMockData(data, timestamp, () => {
+                testMetric('multiObjectDelete', params, expected, done);
+            });
         });
-        testMetric('getBucketVersioning', metricTypes, expected, done);
-    });
 
-    // Putting a delete marker increments deleteObject and numberOfObjects
-    it('should push putDeleteMarkerObject metrics', done => {
-        const expected = getObject(timestamp, {
-            action: 'DeleteObject',
-            numberOfObjects: '1',
+        it('should push getObject metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'GetObject',
+                outgoingBytes: '1024',
+            });
+            Object.assign(params, metricTypes, { newByteLength: 1024 });
+            testMetric('getObject', params, expected, done);
         });
-        testMetric('putDeleteMarkerObject', metricTypes, expected, done);
-    });
 
-    it('should push putBucketReplication metrics', done => {
-        const expected = getObject(timestamp, {
-            action: 'PutBucketReplication',
+        it('should push getObjectAcl metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'GetObjectAcl',
+            });
+            testMetric('getObjectAcl', metricTypes, expected, done);
         });
-        testMetric('putBucketReplication', metricTypes, expected, done);
-    });
 
-    it('should push getBucketReplication metrics', done => {
-        const expected = getObject(timestamp, {
-            action: 'GetBucketReplication',
+        it('should push getObjectTagging metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'GetObjectTagging',
+            });
+            testMetric('getObjectTagging', metricTypes, expected, done);
         });
-        testMetric('getBucketReplication', metricTypes, expected, done);
-    });
 
-    it('should push deleteBucketReplication metrics', done => {
-        const expected = getObject(timestamp, {
-            action: 'DeleteBucketReplication',
+        it('should push putObject metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'PutObject',
+                storageUtilized: '1024',
+                numberOfObjects: '1',
+                incomingBytes: '1024',
+            });
+            Object.assign(params, metricTypes, {
+                newByteLength: 1024,
+                oldByteLength: null,
+            });
+            testMetric('putObject', params, expected, done);
         });
-        testMetric('deleteBucketReplication', metricTypes, expected, done);
-    });
 
-    // Allows for decoupling of projects that use Utapi
-    it('should allow pushing an unsupported metric', done => {
-        const expected = {};
-        testMetric('unsupportedMetric', metricTypes, expected, done);
+        it('should push putObject overwrite metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'PutObject',
+                storageUtilized: '2048',
+                numberOfObjects: '1',
+                incomingBytes: '2048',
+            });
+            Object.assign(params, metricTypes, {
+                newByteLength: 2048,
+                oldByteLength: 1024,
+            });
+            // Set mock data of one, 1024 byte object for `putObject` to
+            // overwrite. Counter does not increment because it is an overwrite.
+            const data = {
+                storageUtilized: '1024',
+                numberOfObjects: '1',
+            };
+            setMockData(data, timestamp, () => {
+                testMetric('putObject', params, expected, done);
+            });
+        });
+
+        it('should push copyObject metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'CopyObject',
+                storageUtilized: '1024',
+                numberOfObjects: '1',
+            });
+            Object.assign(params, metricTypes, {
+                newByteLength: 1024,
+                oldByteLength: null,
+            });
+            testMetric('copyObject', params, expected, done);
+        });
+
+        it('should push copyObject overwrite metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'CopyObject',
+                storageUtilized: '2048',
+                numberOfObjects: '1',
+            });
+            Object.assign(params, metricTypes, {
+                newByteLength: 2048,
+                oldByteLength: 1024,
+            });
+            // Set mock data of one, 1024 byte object for `copyObject` to
+            // overwrite. Counter does not increment because it is an overwrite.
+            const data = {
+                storageUtilized: '1024',
+                numberOfObjects: '1',
+            };
+            setMockData(data, timestamp, () => {
+                testMetric('copyObject', params, expected, done);
+            });
+        });
+
+        it('should push putData metrics', done => {
+            const expected = buildExpectedResult({
+                storageUtilized: '1024',
+                numberOfObjects: '1',
+                incomingBytes: '1024',
+            });
+            Object.assign(params, metricTypes, {
+                newByteLength: 1024,
+                oldByteLength: null,
+            });
+            testMetric('putData', params, expected, done);
+        });
+
+        it('should push putObjectAcl metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'PutObjectAcl',
+            });
+            testMetric('putObjectAcl', metricTypes, expected, done);
+        });
+
+        it('should push putObjectTagging metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'PutObjectTagging',
+            });
+            testMetric('putObjectTagging', metricTypes, expected, done);
+        });
+
+        it('should push deleteObjectTagging metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'DeleteObjectTagging',
+            });
+            testMetric('deleteObjectTagging', metricTypes, expected, done);
+        });
+
+        it('should push headBucket metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'HeadBucket',
+            });
+            testMetric('headBucket', metricTypes, expected, done);
+        });
+
+        it('should push headObject metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'HeadObject',
+            });
+            testMetric('headObject', metricTypes, expected, done);
+        });
+
+        it('should push putBucketVersioning metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'PutBucketVersioning',
+            });
+            testMetric('putBucketVersioning', metricTypes, expected, done);
+        });
+
+        it('should push getBucketVersioning metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'GetBucketVersioning',
+            });
+            testMetric('getBucketVersioning', metricTypes, expected, done);
+        });
+
+        // Putting a delete marker increments deleteObject and numberOfObjects
+        it('should push putDeleteMarkerObject metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'DeleteObject',
+                numberOfObjects: '1',
+            });
+            testMetric('putDeleteMarkerObject', metricTypes, expected, done);
+        });
+
+        it('should push putBucketReplication metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'PutBucketReplication',
+            });
+            testMetric('putBucketReplication', metricTypes, expected, done);
+        });
+
+        it('should push getBucketReplication metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'GetBucketReplication',
+            });
+            testMetric('getBucketReplication', metricTypes, expected, done);
+        });
+
+        it('should push deleteBucketReplication metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'DeleteBucketReplication',
+            });
+            testMetric('deleteBucketReplication', metricTypes, expected, done);
+        });
+
+        // Allows for decoupling of projects that use Utapi
+        it('should allow pushing an unsupported metric', done => {
+            const expected = {};
+            testMetric('unsupportedMetric', metricTypes, expected, done);
+        });
     });
 });


### PR DESCRIPTION
Some customers may only need the metrics of `storageUtilized` and `numberOfObjects` for billing purposes. In such cases, the user can save significant space in the Redis DB and reduce the rate of its growth by limiting the metrics stored to just those.

To that end this PR introduces a feature that allows the user to not store S3 operation counter metrics (i.e. CreateBucket, PutObject, GetObject, etc.) as they are not needed for the computation of `storageUtilized` or `numberOfObjects`. Alternatively, the user may specify a select list of counters they want to track, and disable all others.

This feature is made available as configuration properties of `UtapiClient`. All operation counters are enabled by default (i.e. the original behavior). To disable all operation counters, the user may set `disableOperationCounters` to `true` in the configuration. Alternatively, if specifying `enabledOperationCounters`, only those operation counter will be enabled at the exclusion of all others.