### PR TITLE
bugfix: S3C-2408 MPU overwrite

### DIFF
--- a/lib/UtapiClient.js
+++ b/lib/UtapiClient.js
@@ -634,6 +634,57 @@ class UtapiClient {
         });
     }
 
+    _multipartUploadOverwrite(params, timestamp, action, log, cb) {
+        const counterCommands = [];
+        const levels = this._getParamsArr(params);
+
+        levels.forEach(level => {
+            const key = generateCounter(level, 'storageUtilizedCounter');
+            counterCommands.push(['decrby', key, params.oldByteLength]);
+
+            if (this._isCounterEnabled(action)) {
+                const key = generateKey(level, action, timestamp);
+                counterCommands.push(['incr', key]);
+            }
+        });
+
+        return this.ds.batch(counterCommands, (err, res) => {
+            if (err) {
+                log.error('error decrementing counter for push metric', {
+                    method: 'UtapiClient._multipartUploadOverwrite',
+                    error: err,
+                });
+                return this._pushLocalCache(params, action, timestamp, log, cb);
+            }
+
+            const commandErr = res.find(i => i[0]);
+            if (commandErr) {
+                log.error('error decrementing counter for push metric', {
+                    method: 'UtapiClient._multipartUploadOverwrite',
+                    error: commandErr,
+                });
+                return this._pushLocalCache(params, action, timestamp, log, cb);
+            }
+
+            const sortedSetCommands = [];
+
+            levels.forEach((level, i) => {
+                const key = generateStateKey(level, 'storageUtilized');
+                // We want the result of the storage utilized counter update
+                // that is the first of every group of levels.
+                const groupSize = counterCommands.length / levels.length;
+                const value = res[i * groupSize][1];
+                const storageUtilized = Number.parseInt(value, 10);
+                sortedSetCommands.push(
+                    ['zremrangebyscore', key, timestamp, timestamp],
+                    ['zadd', key, timestamp, member.serialize(storageUtilized)]
+                );
+            });
+
+            return this.ds.batch(sortedSetCommands, cb);
+        });
+    }
+
     /**
     * Updates counter for CompleteMultipartUpload action
     * @param {object} params - params for the metrics
@@ -650,6 +701,13 @@ class UtapiClient {
         this._checkProperties(params);
         this._logMetric(params, '_pushMetricCompleteMultipartUpload', timestamp,
             log);
+
+        // Is the MPU completion overwriting an object?
+        if (params.oldByteLength !== null) {
+            return this._multipartUploadOverwrite(
+                params, timestamp, action, log, callback);
+        }
+
         const paramsArr = this._getParamsArr(params);
         const cmds = [];
         paramsArr.forEach(p => {

--- a/tests/functional/cron/testReplay.js
+++ b/tests/functional/cron/testReplay.js
@@ -101,6 +101,10 @@ function getParams(action) {
             byteLength: objSize,
             numberOfObjects: 2,
         });
+    case 'completeMultipartUpload':
+        return Object.assign(resources, {
+            oldByteLength: null,
+        });
     default:
         return resources;
     }

--- a/tests/unit/testUtapiClient.js
+++ b/tests/unit/testUtapiClient.js
@@ -412,7 +412,30 @@ tests.forEach(test => {
                 action: 'CompleteMultipartUpload',
                 numberOfObjects: '1',
             });
-            testMetric('completeMultipartUpload', metricTypes, expected, done);
+            Object.assign(params, metricTypes, {
+                oldByteLength: null,
+            });
+            testMetric('completeMultipartUpload', params, expected, done);
+        });
+
+        it('should push completeMultipartUpload overwrite metrics', done => {
+            // Seed data includes an object and uploaded parts storage.
+            const data = {
+                storageUtilized: '1024',
+                numberOfObjects: '1',
+            };
+            setMockData(data, timestamp, () => {
+                // Seed object to overwrite is 512 bytes.
+                Object.assign(params, metricTypes, {
+                    oldByteLength: 512,
+                });
+                const expected = buildExpectedResult({
+                    action: 'CompleteMultipartUpload',
+                    storageUtilized: '512',
+                    numberOfObjects: '1',
+                });
+                testMetric('completeMultipartUpload', params, expected, done);
+            });
         });
 
         it('should push listMultipartUploads metrics', done => {


### PR DESCRIPTION
**Overview**
When a MPU object overwrites another object in a non-versioned bucket, the storage utilized and number of objects is incorrect.

**Cause**
The storage utilized values are incremented as parts are uploaded, and not during the complete MPU. Because no storage utilized metrics are updated during a complete MPU operation, an overwritten object is not accounted for.

**Proposed Solution**
When a complete MPU operation succeeds and it is overwriting an object, pass `oldByteLength` as a parameter and decrement the storage utilized value accordingly. Additionally, instead of incrementing the number of objects count, do not modify the value.