### PR TITLE
bugfix: 2475 utapi response corrections

### DIFF
--- a/router/Router.js
+++ b/router/Router.js
@@ -52,6 +52,9 @@ class Router {
         req.on('data', data => body.push(data))
         .on('error', cb)
         .on('end', () => {
+            if (req.method === 'GET') {
+                return cb(errors.AccessForbidden);
+            }
             const jsonParseRes = safeJsonParse(body.join(''));
             if (jsonParseRes.error) {
                 return cb(errors.InvalidParameterValue);

--- a/tests/functional/server/testInvalidRequests.js
+++ b/tests/functional/server/testInvalidRequests.js
@@ -1,0 +1,58 @@
+const assert = require('assert');
+const { errors } = require('arsenal');
+const { makeUtapiGenericClientRequest } = require('../../utils/utils');
+const Vault = require('../../utils/mock/Vault');
+
+describe('Invalid requests', () => {
+    const vault = new Vault();
+
+    before(() => {
+        vault.start();
+    });
+
+    after(() => {
+        vault.end();
+    });
+
+    const tests = [
+        {
+            describe: 'should forbid a GET request ',
+            header: {
+                host: 'localhost',
+                port: 8100,
+                method: 'GET',
+                service: 's3',
+                path: '/cms/hdr.php?pg=<script>alert(document.domain)</script>',
+            },
+            body: {},
+            response: errors.AccessForbidden,
+        },
+        {
+            describe: 'should forbid a GET request ',
+            header: {
+                host: 'localhost',
+                port: 8100,
+                method: 'GET',
+                service: 's3',
+                path: '/buckets/Action=ListMetrics',
+            },
+            body: {},
+            response: errors.AccessForbidden,
+        },
+    ];
+
+    tests.forEach(test => {
+        it(`${test.describe}`, done => {
+            makeUtapiGenericClientRequest(test.header, test.body,
+                (err, response) => {
+                    if (err) {
+                        return done(err);
+                    }
+                    const data = JSON.parse(response);
+                    assert.deepStrictEqual(test.response.description,
+                        data.message);
+                    return done();
+                });
+        });
+    });
+});

--- a/tests/utils/utils.js
+++ b/tests/utils/utils.js
@@ -115,6 +115,30 @@ function makeUtapiClientRequest({ timeRange, resource }, cb) {
     req.end();
 }
 
+function makeUtapiGenericClientRequest(reqHeader, reqBody, cb) {
+    const header = Object.assign({
+        host: 'localhost',
+        port: 8100,
+        service: 's3',
+    }, reqHeader);
+    const credentials = {
+        accessKeyId: 'accessKey1',
+        secretAccessKey: 'verySecretKey1',
+    };
+    const options = aws4.sign(header, credentials);
+    const req = http.request(options, res => {
+        const body = [];
+        res.on('data', chunk => body.push(chunk));
+        res.on('end', () => cb(null, `${body.join('')}`));
+    });
+    req.on('error', err => cb(err));
+    if (header.method === 'POST') {
+        const body = Object.assign({}, reqBody);
+        req.write(JSON.stringify(body));
+    }
+    req.end();
+}
+
 function _getNormalizedTimestamp() {
     const d = new Date();
     const minutes = d.getMinutes();
@@ -172,4 +196,5 @@ module.exports = {
     getNormalizedTimestamp,
     buildMockResponse,
     makeUtapiClientRequest,
+    makeUtapiGenericClientRequest,
 };


### PR DESCRIPTION
### Why is this change required? What problem does it solve?
Utapi responses does not match AWS responses on invalid requests, it is now corrected to respond with correct responses.