### PR TITLE
bugfix: S3C-2604-list-multiple-bucket-metrics

### DIFF
--- a/router/Router.js
+++ b/router/Router.js
@@ -213,13 +213,12 @@ class Router {
         const validator = utapiRequest.getValidator();
         // specific resources will be names of buckets, accounts or users
         const specificResources = validator.get(resourceType);
-
-        const requestContexts = specificResources.map(specificResource =>
+        const requestContext = [];
+        requestContext.push(
             new policies.RequestContext(utapiRequest.getRequestHeaders(),
-            utapiRequest.getRequestQuery(), resourceType, specificResource,
-            utapiRequest.getRequesterIp(), utapiRequest.getSslEnabled(),
-            utapiRequest.getAction(), 'utapi')
-        );
+                utapiRequest.getRequestQuery(), resourceType, specificResources,
+                utapiRequest.getRequesterIp(), utapiRequest.getSslEnabled(),
+                utapiRequest.getAction(), 'utapi'));
         auth.setHandler(this._vault);
         const request = utapiRequest.getRequest();
         request.path = utapiRequest.getRequestPathname();
@@ -254,7 +253,7 @@ class Router {
             log.trace('passed security checks');
             return cb();
         },
-        's3', requestContexts);
+        's3', requestContext);
     }
 
     /**


### PR DESCRIPTION
**What does this PR do, and why do we need it?**
> Combined the _specificResource when the type of resource requested is 'bucket'. So instead of having multiple requestContexts we will have all the requests combined into one.
> Post NodeJS upgrade we could not query more than 7 buckets as in the new node version they introduced a limit of 8KB for HTTP packet parsing, commit in Node.js for reference  https://github.com/nodejs/node/commit/a8532d4d23.
> Customer reply on metrics supplied by UTAPI to charge their customers

**Which issue does this PR fix?**
fixes #[S3C-2604](https://scality.atlassian.net/browse/S3C-2604)

**Special notes for your reviewers**:
This is a quick workaround, we are gonna re-architecture UTAPI eventually.