### PR TITLE
INTEGRATION [PR#475 > development/8.1] Feature/s3 c 2960 object lock metrics

### DIFF
--- a/lib/UtapiClient.js
+++ b/lib/UtapiClient.js
@@ -58,11 +58,15 @@ const methods = {
     },
     getObject: { method: '_pushMetricGetObject', changesData: false },
     getObjectAcl: { method: '_genericPushMetric', changesData: false },
+    getObjectLegalHold: { method: '_genericPushMetric', changesData: false },
+    getObjectRetention: { method: '_genericPushMetric', changesData: false },
     getObjectTagging: { method: '_genericPushMetric', changesData: false },
     putObject: { method: '_genericPushMetricPutObject', changesData: true },
     copyObject: { method: '_genericPushMetricPutObject', changesData: true },
     putData: { method: '_genericPushMetricPutObject', changesData: true },
     putObjectAcl: { method: '_genericPushMetric', changesData: true },
+    putObjectLegalHold: { method: '_genericPushMetric', changesData: true },
+    putObjectRetention: { method: '_genericPushMetric', changesData: true },
     putObjectTagging: { method: '_genericPushMetric', changesData: true },
     deleteObjectTagging: { method: '_genericPushMetric', changesData: true },
     headBucket: { method: '_genericPushMetric', changesData: false },
@@ -85,6 +89,8 @@ const methods = {
         method: '_genericPushMetric',
         changesData: true,
     },
+    putBucketObjectLock: { method: '_genericPushMetric', changesData: true },
+    getBucketObjectLock: { method: '_genericPushMetric', changesData: true },
 };
 
 const metricObj = {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -46,6 +46,12 @@ const keys = {
     putBucketReplication: prefix => `${prefix}PutBucketReplication`,
     getBucketReplication: prefix => `${prefix}GetBucketReplication`,
     deleteBucketReplication: prefix => `${prefix}DeleteBucketReplication`,
+    putBucketObjectLock: prefix => `${prefix}PutBucketObjectLock`,
+    getBucketObjectLock: prefix => `${prefix}GetBucketObjectLock`,
+    putObjectRetention: prefix => `${prefix}PutObjectRetention`,
+    getObjectRetention: prefix => `${prefix}GetObjectRetention`,
+    putObjectLegalHold: prefix => `${prefix}PutObjectLegalHold`,
+    getObjectLegalHold: prefix => `${prefix}GetObjectLegalHold`,
     incomingBytes: prefix => `${prefix}incomingBytes`,
     outgoingBytes: prefix => `${prefix}outgoingBytes`,
 };

--- a/models/s3metricResponse.json
+++ b/models/s3metricResponse.json
@@ -40,6 +40,12 @@
         "s3:GetBucketVersioning": 0,
         "s3:PutBucketReplication": 0,
         "s3:GetBucketReplication": 0,
-        "s3:DeleteBucketReplication": 0
+        "s3:DeleteBucketReplication": 0,
+        "s3:PutBucketObjectLock": 0,
+        "s3:GetBucketObjectLock": 0,
+        "s3:PutObjectRetention": 0,
+        "s3:GetObjectRetention": 0,
+        "s3:PutObjectLegalHold": 0,
+        "s3:GetObjectLegalHold": 0
     }
 }

--- a/tests/functional/cron/testReplay.js
+++ b/tests/functional/cron/testReplay.js
@@ -65,6 +65,12 @@ const actions = [
     'putBucketReplication',
     'getBucketReplication',
     'deleteBucketReplication',
+    'putBucketObjectLock',
+    'getBucketObjectLock',
+    'putObjectRetention',
+    'getObjectRetention',
+    'putObjectLegalHold',
+    'getObjectLegalHold',
 ];
 
 // Get the proper params object for a pushMetric call for the given action.

--- a/tests/unit/testMetrics.js
+++ b/tests/unit/testMetrics.js
@@ -435,6 +435,30 @@ Object.keys(metricLevels).forEach(schemaKey => {
                     done,
                 ),
         );
+
+        it(`should return ${metric} level metrics for put bucket object lock`,
+            done => testOps(schemaKey, 'putBucketObjectLock',
+                's3:PutBucketObjectLock', false, done));
+
+        it(`should return ${metric} level metrics for get bucket object lock`,
+            done => testOps(schemaKey, 'getBucketObjectLock',
+                's3:GetBucketObjectLock', false, done));
+
+        it(`should return ${metric} level metrics for put object retention`,
+            done => testOps(schemaKey, 'putObjectRetention',
+                's3:PutObjectRetention', false, done));
+
+        it(`should return ${metric} level metrics for get object retention`,
+            done => testOps(schemaKey, 'getObjectRetention',
+                's3:GetObjectRetention', false, done));
+
+        it(`should return ${metric} level metrics for put object legal hold`,
+            done => testOps(schemaKey, 'putObjectLegalHold',
+                's3:PutObjectLegalHold', false, done));
+
+        it(`should return ${metric} level metrics for get object legal hold`,
+            done => testOps(schemaKey, 'getObjectLegalHold',
+                's3:GetObjectLegalHold', false, done));
     });
 });
 

--- a/tests/unit/testUtapiClient.js
+++ b/tests/unit/testUtapiClient.js
@@ -188,6 +188,12 @@ const tests = [
                 'PutBucketReplication',
                 'GetBucketReplication',
                 'DeleteBucketReplication',
+                'PutBucketObjectLock',
+                'GetBucketObjectLock',
+                'PutObjectRetention',
+                'GetObjectRetention',
+                'PutObjectLegalHold',
+                'GetObjectLegalHold',
             ],
         },
     },
@@ -690,6 +696,48 @@ tests.forEach(test => {
                 action: 'DeleteBucketReplication',
             });
             testMetric('deleteBucketReplication', metricTypes, expected, done);
+        });
+
+        it('should push putBucketObjectLock metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'PutBucketObjectLock',
+            });
+            testMetric('putBucketObjectLock', metricTypes, expected, done);
+        });
+
+        it('should push getBucketObjectLock metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'GetBucketObjectLock',
+            });
+            testMetric('getBucketObjectLock', metricTypes, expected, done);
+        });
+
+        it('should push putObjectRetention metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'PutObjectRetention',
+            });
+            testMetric('putObjectRetention', metricTypes, expected, done);
+        });
+
+        it('should push getObjectRetention metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'GetObjectRetention',
+            });
+            testMetric('getObjectRetention', metricTypes, expected, done);
+        });
+
+        it('should push putObjectLegalHold metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'PutObjectLegalHold',
+            });
+            testMetric('putObjectLegalHold', metricTypes, expected, done);
+        });
+
+        it('should push getObjectLegalHold metrics', done => {
+            const expected = buildExpectedResult({
+                action: 'GetObjectLegalHold',
+            });
+            testMetric('getObjectLegalHold', metricTypes, expected, done);
         });
 
         // Allows for decoupling of projects that use Utapi

--- a/tests/utils/utils.js
+++ b/tests/utils/utils.js
@@ -87,6 +87,12 @@ function buildMockResponse({ start, end, val }) {
             's3:PutBucketReplication': val,
             's3:GetBucketReplication': val,
             's3:DeleteBucketReplication': val,
+            's3:PutBucketObjectLock': val,
+            's3:GetBucketObjectLock': val,
+            's3:PutObjectRetention': val,
+            's3:GetObjectRetention': val,
+            's3:PutObjectLegalHold': val,
+            's3:GetObjectLegalHold': val,
         },
         bucketName: 'utapi-bucket',
     };


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #475.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/feature/S3C-2960-object-lock-metrics`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/feature/S3C-2960-object-lock-metrics
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/feature/S3C-2960-object-lock-metrics
```

Please always comment pull request #475 instead of this one.