### PR TITLE
INTEGRATION [PR#525 > development/8.1] Add shard tracking to redis backend and expose through cache client

### DIFF
--- a/libV2/cache/client.js
+++ b/libV2/cache/client.js
@@ -30,6 +30,10 @@ class CacheClient {
     async shardExists(shard) {
         return this._backend.shardExists(shard);
     }
+
+    async getShards() {
+        return this._backend.getShards();
+    }
 }
 
 module.exports = CacheClient;

--- a/libV2/cache/schema.js
+++ b/libV2/cache/schema.js
@@ -1,4 +1,3 @@
-
 function getShardKey(prefix, shard) {
     return `${prefix}:shard:${shard}`;
 }
@@ -7,8 +6,12 @@ function getUtapiMetricKey(prefix, metric) {
     return `${prefix}:events:${metric.uuid}`;
 }
 
+function getShardMasterKey(prefix) {
+    return `${prefix}:shard:master`;
+}
 
 module.exports = {
     getShardKey,
     getUtapiMetricKey,
+    getShardMasterKey,
 };


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #525.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/feature/S3C-3001_Add_shard_tracking_to_redis_backend`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/feature/S3C-3001_Add_shard_tracking_to_redis_backend
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/feature/S3C-3001_Add_shard_tracking_to_redis_backend
```

Please always comment pull request #525 instead of this one.