### PR TITLE
INTEGRATION [PR#598 > development/7.8] bf(S3C-3235): Fix Exception when calling getMetricsAt with an empty DB

### DIFF
--- a/warpscript/util/sumRecord.mc2
+++ b/warpscript/util/sumRecord.mc2
@@ -28,7 +28,14 @@ Sums 2 internal UTAPI records returning a new record containing the result
     'b' STORE
     CLONE [ 'a' 'result' ] STORE
 
-    $a 'ops' GET CLONE SWAP DROP 'resultOps' STORE
+    $a 'ops' GET
+
+    <% DUP ISNULL ! %>
+    <% CLONE SWAP DROP %>
+    <% DROP {} %>
+    IFTE
+
+    'resultOps' STORE
     $result $resultOps 'ops' PUT
 
     'objD' $b 'objD' GET @util/sumField


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #598.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.8/bugfix/S3C-3235_fix_getMetricsAt_with_no_data`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.8/bugfix/S3C-3235_fix_getMetricsAt_with_no_data
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.8/bugfix/S3C-3235_fix_getMetricsAt_with_no_data
```

Please always comment pull request #598 instead of this one.