### PR TITLE
INTEGRATION [PR#624 > development/8.1] bf(S3C-3255): Ensure ingested events timestamp precision

### DIFF
--- a/libV2/server/API/metrics/ingestMetric.js
+++ b/libV2/server/API/metrics/ingestMetric.js
@@ -1,11 +1,15 @@
 const errors = require('../../../errors');
 const { UtapiMetric } = require('../../../models');
 const { client: cacheClient } = require('../../../cache');
+const { convertTimestamp } = require('../../../utils');
 
 async function ingestMetric(ctx, params) {
     let metrics;
     try {
-        metrics = params.body.map(m => new UtapiMetric(m));
+        metrics = params.body.map(m => new UtapiMetric({
+            ...m,
+            timestamp: convertTimestamp(m.timestamp),
+        }));
     } catch (error) {
         throw errors.InvalidRequest;
     }

--- a/tests/unit/v2/API/metrics/testIngestMetric.js
+++ b/tests/unit/v2/API/metrics/testIngestMetric.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const sinon = require('sinon');
 const ingestMetric = require('../../../../../libV2/server/API/metrics/ingestMetric');
 const { client: cacheClient } = require('../../../../../libV2/cache');
-
+const { convertTimestamp } = require('../../../../../libV2/utils');
 const { generateFakeEvents, templateContext } = require('../../../../utils/v2Data');
 
 const events = generateFakeEvents(1, 50, 50);
@@ -19,7 +19,10 @@ describe('Test ingestMetric', () => {
         const spy = sinon.spy(cacheClient, 'pushMetric');
         await ingestMetric(ctx, { body: events.map(ev => ev.getValue()) });
         assert.strictEqual(ctx.results.statusCode, 200);
-        events.forEach(ev => assert(spy.calledWith(ev)));
+        events.forEach(ev => assert(spy.calledWith({
+            ...ev,
+            timestamp: convertTimestamp(ev.timestamp),
+        })));
     });
 
     it('should throw InvalidRequest if metric data is invalid',


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #624.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-3255_ensure_ingest_timestamp_precision`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-3255_ensure_ingest_timestamp_precision
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-3255_ensure_ingest_timestamp_precision
```

Please always comment pull request #624 instead of this one.