### PR TITLE
INTEGRATION [PR#651 > development/8.1] ft(S3C-3324): Add counter backend to cache

### DIFF
--- a/libV2/cache/backend/memory.js
+++ b/libV2/cache/backend/memory.js
@@ -1,10 +1,23 @@
 const schema = require('../schema');
+const constants = require('../../constants');
+
+/**
+ * Returns null iff the value is undefined.
+ * Returns the passed value otherwise.
+ *
+ * @param {*} value - Any value
+ * @returns {*} - PAssed value or null
+ */
+function orNull(value) {
+    return value === undefined ? null : value;
+}
 
 class MemoryCache {
     constructor() {
         this._data = {};
         this._shards = {};
         this._prefix = 'utapi';
+        this._expirations = {};
     }
 
     // eslint-disable-next-line class-methods-use-this
@@ -14,7 +27,15 @@ class MemoryCache {
 
     // eslint-disable-next-line class-methods-use-this
     async disconnect() {
+        Object.values(this._expirations).forEach(clearTimeout);
         return true;
+    }
+
+    _expireKey(key, delay) {
+        if (this._expirations[key]) {
+            clearTimeout(this._expirations[key]);
+        }
+        this._expirations[key] = setTimeout(() => delete this._data[key], delay * 1000);
     }
 
     async getKey(key) {
@@ -62,6 +83,27 @@ class MemoryCache {
 
     async shardExists(shard) {
         return this._shards[shard.toString()] !== undefined;
+    }
+
+    async updateCounters(metric) {
+        if (metric.sizeDelta) {
+            const accountSizeKey = schema.getAccountSizeCounterKey(this._prefix, metric.account);
+            this._data[accountSizeKey] = (this._data[accountSizeKey] || 0) + metric.sizeDelta;
+        }
+    }
+
+    async updateAccountCounterBase(account, size) {
+        const accountSizeKey = schema.getAccountSizeCounterKey(this._prefix, account);
+        const accountSizeBaseKey = schema.getAccountSizeCounterBaseKey(this._prefix, account);
+        this._data[accountSizeKey] = 0;
+        this._data[accountSizeBaseKey] = size;
+        this._expireKey(accountSizeBaseKey, constants.counterBaseValueExpiration);
+    }
+
+    async fetchAccountSizeCounter(account) {
+        const accountSizeKey = schema.getAccountSizeCounterKey(this._prefix, account);
+        const accountSizeBaseKey = schema.getAccountSizeCounterBaseKey(this._prefix, account);
+        return [orNull(this._data[accountSizeKey]), orNull(this._data[accountSizeBaseKey])];
     }
 }
 

--- a/libV2/cache/client.js
+++ b/libV2/cache/client.js
@@ -3,36 +3,55 @@ const { shardFromTimestamp } = require('../utils');
 class CacheClient {
     constructor(config) {
         this._prefix = config.prefix || 'utapi';
-        this._backend = config.backend;
+        this._cacheBackend = config.cacheBackend;
+        this._counterBackend = config.counterBackend;
     }
 
     async connect() {
-        return this._backend.connect();
+        return Promise.all([
+            this._cacheBackend.connect(),
+            this._counterBackend.connect(),
+        ]);
     }
 
     async disconnect() {
-        return this._backend.disconnect();
+        return Promise.all([
+            this._cacheBackend.disconnect(),
+            this._counterBackend.disconnect(),
+        ]);
     }
 
     async pushMetric(metric) {
         const shard = shardFromTimestamp(metric.timestamp);
-        return this._backend.addToShard(shard, metric);
+        if (!this._cacheBackend.addToShard(shard, metric)) {
+            return false;
+        }
+        await this._counterBackend.updateCounters(metric);
+        return true;
     }
 
     async getMetricsForShard(shard) {
-        return this._backend.fetchShard(shard);
+        return this._cacheBackend.fetchShard(shard);
     }
 
     async deleteShard(shard) {
-        return this._backend.deleteShardAndKeys(shard);
+        return this._cacheBackend.deleteShardAndKeys(shard);
     }
 
     async shardExists(shard) {
-        return this._backend.shardExists(shard);
+        return this._cacheBackend.shardExists(shard);
     }
 
     async getShards() {
-        return this._backend.getShards();
+        return this._cacheBackend.getShards();
+    }
+
+    async updateAccountCounterBase(account, size) {
+        return this._counterBackend.updateAccountCounterBase(account, size);
+    }
+
+    async fetchAccountSizeCounter(account) {
+        return this._counterBackend.fetchAccountSizeCounter(account);
     }
 }
 

--- a/libV2/cache/index.js
+++ b/libV2/cache/index.js
@@ -4,11 +4,12 @@ const CacheClient = require('./client');
 const { MemoryCache, RedisCache } = require('./backend');
 
 const cacheTypes = {
-    redis: () => new RedisCache(config.cache),
+    redis: conf => new RedisCache(conf),
     memory: () => new MemoryCache(),
 };
 
-const backend = cacheTypes[config.cache.backend]();
+const cacheBackend = cacheTypes[config.cache.backend](config.cache);
+const counterBackend = cacheTypes[config.cache.backend](config.redis);
 
 module.exports = {
     CacheClient,
@@ -16,5 +17,5 @@ module.exports = {
         MemoryCache,
         RedisCache,
     },
-    client: new CacheClient({ backend }),
+    client: new CacheClient({ cacheBackend, counterBackend }),
 };

--- a/libV2/cache/schema.js
+++ b/libV2/cache/schema.js
@@ -10,8 +10,18 @@ function getShardMasterKey(prefix) {
     return `${prefix}:shard:master`;
 }
 
+function getAccountSizeCounterKey(prefix, account) {
+    return `${prefix}:counters:account:${account}:size`;
+}
+
+function getAccountSizeCounterBaseKey(prefix, account) {
+    return `${prefix}:counters:account:${account}:size:base`;
+}
+
 module.exports = {
     getShardKey,
     getUtapiMetricKey,
     getShardMasterKey,
+    getAccountSizeCounterKey,
+    getAccountSizeCounterBaseKey,
 };

--- a/libV2/config/defaults.json
+++ b/libV2/config/defaults.json
@@ -5,6 +5,10 @@
         "logLevel": "info",
         "dumpLevel": "error"
     },
+    "redis": {
+        "host": "127.0.0.1",
+        "port": 6379
+    },
     "localCache": {
         "host": "127.0.0.1",
         "port": 6379

--- a/libV2/constants.js
+++ b/libV2/constants.js
@@ -90,6 +90,7 @@ const constants = {
     checkpointLagSecs: 300,
     snapshotLagSecs: 900,
     repairLagSecs: 5,
+    counterBaseValueExpiration: 86400, // 24hrs
 };
 
 constants.operationToResponse = constants.operations

--- a/tests/unit/v2/cache/testMemoryBackend.js
+++ b/tests/unit/v2/cache/testMemoryBackend.js
@@ -103,4 +103,27 @@ describe('Test cache memory backend', () => {
             assert(res, true);
         });
     });
+
+    it('should update the account size counter', async () => {
+        await Promise.all(testValues.map(event => mem.updateCounters(event)));
+        const expectedKey = schema.getAccountSizeCounterKey('utapi', testValues[0].account);
+        const expectedValue = testValues.reduce((prev, event) => prev + (event.sizeDelta || 0), 0);
+        assert.deepStrictEqual(mem._data, { [expectedKey]: expectedValue });
+    });
+
+    it('should update the account size counter base', async () => {
+        await mem.updateAccountCounterBase('imanaccount', 1);
+        const baseKey = schema.getAccountSizeCounterBaseKey('utapi', 'imanaccount');
+        const counterKey = schema.getAccountSizeCounterKey('utapi', 'imanaccount');
+        assert.deepStrictEqual(mem._data, { [baseKey]: 1, [counterKey]: 0 });
+    });
+
+    it('should fetch the account size counter  and base', async () => {
+        const { account } = testValues[0];
+        await mem.updateAccountCounterBase(account, 1);
+        await Promise.all(testValues.map(event => mem.updateCounters(event)));
+        const counterValue = testValues.reduce((prev, event) => prev + (event.sizeDelta || 0), 0);
+        const res = await mem.fetchAccountSizeCounter(account);
+        assert.deepStrictEqual(res, [counterValue, 1]);
+    });
 });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #651.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/feature/S3C-3324_add_counter_backend_to_cache`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/feature/S3C-3324_add_counter_backend_to_cache
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/feature/S3C-3324_add_counter_backend_to_cache
```

Please always comment pull request #651 instead of this one.