### PR TITLE
INTEGRATION [PR#659 > development/7.7] ft(S3C-3351): Cache js dependencies in buildbot worker backport to 7.4

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,1 +1,11 @@
-{ "extends": "scality" }
+{
+  "extends": "scality",
+  "settings": {
+      "import/resolver": {
+        "node": {
+          "paths": ["/utapi/node_modules", "node_modules"]
+        }
+      }
+    }
+}
+

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -16,11 +16,9 @@ models:
       type: kube_pod
       path: eve/workers/pod.yml
       images:
-        aggressor: eve/workers/unit_and_feature_tests
-  - Install: &install
-      name: install node modules
-      command: yarn install --frozen-lockfile
-      haltOnFailure: True
+        aggressor:
+          context: '.'
+          dockerfile: eve/workers/unit_and_feature_tests/Dockerfile
 
 stages:
   pre-merge:
@@ -40,7 +38,6 @@ stages:
     worker: *workspace
     steps:
       - Git: *clone
-      - ShellCommand: *install
       - ShellCommand:
           name: run static analysis tools on markdown
           command: yarn run lint_md
@@ -51,7 +48,6 @@ stages:
     worker: *workspace
     steps:
       - Git: *clone
-      - ShellCommand: *install
       - ShellCommand:
           name: run unit tests
           command: yarn test
@@ -59,7 +55,6 @@ stages:
     worker: *workspace
     steps:
       - Git: *clone
-      - ShellCommand: *install
       - ShellCommand:
           name: run client tests
           command: bash ./eve/workers/unit_and_feature_tests/run_ft_tests.bash false ft_test:client
@@ -67,7 +62,6 @@ stages:
     worker: *workspace
     steps:
       - Git: *clone
-      - ShellCommand: *install
       - ShellCommand:
           name: run server tests
           command: bash ./eve/workers/unit_and_feature_tests/run_ft_tests.bash false ft_test:server
@@ -75,7 +69,6 @@ stages:
     worker: *workspace
     steps:
       - Git: *clone
-      - ShellCommand: *install
       - ShellCommand:
           name: run cron tests
           command: bash ./eve/workers/unit_and_feature_tests/run_ft_tests.bash false ft_test:cron
@@ -83,7 +76,6 @@ stages:
     worker: *workspace
     steps:
       - Git: *clone
-      - ShellCommand: *install
       - ShellCommand:
           name: run interval tests
           command: bash ./eve/workers/unit_and_feature_tests/run_ft_tests.bash true ft_test:interval

--- a/eve/workers/unit_and_feature_tests/Dockerfile
+++ b/eve/workers/unit_and_feature_tests/Dockerfile
@@ -3,12 +3,18 @@ FROM buildpack-deps:jessie-curl
 #
 # Install apt packages needed by utapi and buildbot_worker
 #
+
 ENV LANG C.UTF-8
 ENV NODE_VERSION 10.22.0
-COPY utapi_packages.list buildbot_worker_packages.list /tmp/
+ENV PATH=$PATH:/utapi/node_modules/.bin
+ENV NODE_PATH=/utapi/node_modules
+
+COPY eve/workers/unit_and_feature_tests/utapi_packages.list eve/workers/unit_and_feature_tests/buildbot_worker_packages.list /tmp/
+
+WORKDIR /utapi
 
 RUN wget https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.gz \
-    && tar -xf node-v${NODE_VERSION}-linux-x64.tar.gz --directory /usr/local --strip-components 1 \ 
+    && tar -xf node-v${NODE_VERSION}-linux-x64.tar.gz --directory /usr/local --strip-components 1 \
     && curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb http://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
     && apt-get update -qq \
@@ -19,7 +25,15 @@ RUN wget https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x6
     && rm -f /etc/supervisor/conf.d/*.conf \
     && rm -f node-v${NODE_VERSION}-linux-x64.tar.gz
 
+#
+# Install yarn dependencies
+#
 
+COPY package.json yarn.lock /utapi/
+
+RUN yarn cache clean \
+    && yarn install --frozen-lockfile \
+    && yarn cache clean
 #
 # Run buildbot-worker on startup through supervisor
 #
@@ -28,7 +42,7 @@ ARG BUILDBOT_VERSION
 RUN pip install buildbot-worker==$BUILDBOT_VERSION
 RUN pip3 install requests
 RUN pip3 install redis
-ADD supervisor/buildbot_worker.conf /etc/supervisor/conf.d/
-ADD redis/sentinel.conf /etc/sentinel.conf
+ADD eve/workers/unit_and_feature_tests/supervisor/buildbot_worker.conf /etc/supervisor/conf.d/
+ADD eve/workers/unit_and_feature_tests/redis/sentinel.conf /etc/sentinel.conf
 
 CMD ["supervisord", "-n"]


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #659.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.7/feature/S3C-3351_cache_node_deps_backport`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.7/feature/S3C-3351_cache_node_deps_backport
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.7/feature/S3C-3351_cache_node_deps_backport
```

Please always comment pull request #659 instead of this one.