### PR TITLE
INTEGRATION [PR#674 > development/8.1] bf(S3C-3358): Fix metrics response for single resource

### DIFF
--- a/libV2/server/API/metrics/listMetrics.js
+++ b/libV2/server/API/metrics/listMetrics.js
@@ -70,13 +70,7 @@ async function listMetric(ctx, params) {
             return metric;
         });
 
-    // Unwrap the response if only one resource is passed
-    if (resp.length === 1) {
-        [ctx.results.body] = resp;
-    } else {
-        ctx.results.body = resp;
-    }
-
+    ctx.results.body = resp;
     ctx.results.statusCode = 200;
 }
 

--- a/tests/functional/v2/server/testListMetrics.js
+++ b/tests/functional/v2/server/testListMetrics.js
@@ -138,18 +138,9 @@ describe('Test listMetric', function () {
                     const [level, resources] = query;
                     it(`should get metrics for ${level}`, async () => {
                         const resp = await listMetrics(...query, getTs(-500), getTs(0));
-                        if (resources.length === 1) {
-                            // If only one resource is requested the response is an object
-                            assert(!Array.isArray(resp.body));
-                        } else {
-                            // Otherwise it is an Array
-                            assert(Array.isArray(resp.body));
-                        }
+                        assert(Array.isArray(resp.body));
 
-                        let { body } = resp;
-                        if (!Array.isArray(resp.body)) {
-                            body = [body];
-                        }
+                        const { body } = resp;
                         assert.deepStrictEqual(body.map(r => r[metricResponseKeys[level]]), resources);
 
                         body.forEach(metric => {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #674.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-3358_fix_metrics_resp_for_single_resource`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-3358_fix_metrics_resp_for_single_resource
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-3358_fix_metrics_resp_for_single_resource
```

Please always comment pull request #674 instead of this one.