### PR TITLE
ft(S3C-3418): Change wire format to json for warp10 ingestion

### DIFF
--- a/libV2/warp10.js
+++ b/libV2/warp10.js
@@ -9,12 +9,6 @@ const moduleLogger = new LoggerContext({
     module: 'warp10',
 });
 
-function _stringify(value) {
-    if (typeof value === 'number') {
-        return value.toString();
-    }
-    return `'${value}'`;
-}
 
 class Warp10Client {
     constructor(config) {
@@ -56,9 +50,11 @@ class Warp10Client {
     static _packEvent(valueType, event) {
         const packed = Object.entries(event.getValue())
             .filter(([key]) => eventFieldsToWarp10[key])
-            .map(([key, value]) => `'${eventFieldsToWarp10[key]}' ${_stringify(value)}`)
-            .join(' ');
-        return `${valueType}{ ${packed} }`;
+            .reduce((ev, [key, value]) => {
+                ev[eventFieldsToWarp10[key]] = value;
+                return ev;
+            }, {});
+        return `${valueType}${JSON.stringify(packed)}`;
     }
 
     _buildGTSEntry(className, valueType, labels, event) {

--- a/warpscript/utapi/event.mc2
+++ b/warpscript/utapi/event.mc2
@@ -1,3 +1,3 @@
 <%
-  EVAL @utapi/encodeEvent
+  JSON-> @utapi/encodeEvent
 %>

--- a/warpscript/utapi/record.mc2
+++ b/warpscript/utapi/record.mc2
@@ -1,3 +1,3 @@
 <%
-  EVAL @utapi/encodeRecord
+  JSON-> @utapi/encodeRecord
 %>


### PR DESCRIPTION
Drop our bespoke packing into warpscript syntax and switch to JSON. I'm choosing this over extending the existing solution as we don't need to maintain any custom code.