### PR TITLE
INTEGRATION [PR#741 > development/7.8] ft(S3C-3423): Add client ip limiting middleware and openapi spec support

### DIFF
--- a/libV2/server/API/metrics.js
+++ b/libV2/server/API/metrics.js
@@ -1,8 +1,5 @@
 const ApiController = require('../controller');
-const { authenticateV4 } = require('../../vault');
 
-const controller = new ApiController('metrics', [
-    authenticateV4,
-]);
+const controller = new ApiController('metrics');
 
 module.exports = controller.buildMap();

--- a/libV2/server/controller.js
+++ b/libV2/server/controller.js
@@ -67,6 +67,9 @@ class APIController {
         return Object.entries(apiOperationMiddleware[tag])
             .reduce((handlers, [id, handler]) => {
                 const middleware = [];
+                if (handler.iplimit) {
+                    middleware.push(utapiMiddleware.clientIpLimitMiddleware);
+                }
                 if (handler.authv4) {
                     middleware.push(utapiMiddleware.authV4Middleware);
                 }

--- a/libV2/server/middleware.js
+++ b/libV2/server/middleware.js
@@ -1,6 +1,7 @@
 const oasTools = require('oas-tools');
 const path = require('path');
 const { promisify } = require('util');
+const { ipCheck } = require('arsenal');
 const config = require('../config');
 const { logger, buildRequestLogger } = require('../utils');
 const errors = require('../errors');
@@ -129,6 +130,15 @@ async function authV4Middleware(request, response, params) {
     }
 }
 
+async function clientIpLimitMiddleware(request) {
+    const allowIp = ipCheck.ipMatchCidrList(
+        config.healthChecks.allowFrom, request.ip,
+    );
+    if (!allowIp) {
+        throw errors.AccessDenied.customizeDescription('invalid origin ip on request');
+    }
+}
+
 module.exports = {
     initializeOasTools,
     middleware: {
@@ -136,5 +146,6 @@ module.exports = {
         errorMiddleware,
         responseLoggerMiddleware,
         authV4Middleware,
+        clientIpLimitMiddleware,
     },
 };

--- a/libV2/server/spec.js
+++ b/libV2/server/spec.js
@@ -54,6 +54,11 @@ function _getApiOperationMiddleware(routes) {
                     if (op['x-authv4'] === true) {
                         middleware.authv4 = true;
                     }
+
+                    if (op['x-iplimit'] === true) {
+                        middleware.iplimit = true;
+                    }
+
                     optIds[tag][op.operationId] = middleware;
 
                     moduleLogger

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -126,6 +126,7 @@ paths:
   /_/healthcheck:
     get:
       x-router-controller: internal
+      x-iplimit: true
       operationId: healthcheck
       responses:
         default:
@@ -155,7 +156,7 @@ paths:
       - $ref: '#/components/parameters/level'
     get:
       x-router-controller: metrics
-      x-authv4: true
+      x-iplimit: true
       description: Get current storage utilized
       operationId: getStorage
       responses:


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #741.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.8/feature/S3C-3423_add_client_ip_limiting_middleware`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.8/feature/S3C-3423_add_client_ip_limiting_middleware
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.8/feature/S3C-3423_add_client_ip_limiting_middleware
```

Please always comment pull request #741 instead of this one.