### PR TITLE
INTEGRATION [PR#773 > development/8.1] bf(S3C-3438): Add missing reindexSchedule schema entry

### DIFF
--- a/libV2/config/schema.js
+++ b/libV2/config/schema.js
@@ -76,6 +76,7 @@ const schema = Joi.object({
     checkpointSchedule: Joi.string(),
     snapshotSchedule: Joi.string(),
     repairSchedule: Joi.string(),
+    reindexSchedule: Joi.string(),
 });
 
 module.exports = schema;


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #773.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-3438_add_missing_reindex_schema`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-3438_add_missing_reindex_schema
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-3438_add_missing_reindex_schema
```

Please always comment pull request #773 instead of this one.