### PR TITLE
ft(S3C-3484): Add Sensision and extend warp10 tunables

### DIFF
--- a/images/warp10/Dockerfile
+++ b/images/warp10/Dockerfile
@@ -3,10 +3,13 @@ FROM warp10io/warp10:2.6.0
 ENV S6_VERSION 2.0.0.1
 
 ENV WARP10_CONF_TEMPLATES ${WARP10_HOME}/conf.templates/standalone
+ENV SENSISION_DATA_DIR /data/sensision
 
 # Modify Warp 10 default config
 ENV standalone.host 0.0.0.0
+ENV standalone.port 4802
 ENV warpscript.repository.directory /usr/local/share/warpscript
+ENV warp.token.file /static.tokens
 ENV warpscript.extension.protobuf io.warp10.ext.protobuf.ProtobufWarpScriptExtension
 ENV warpscript.extension.macrovalueencoder 'io.warp10.continuum.ingress.MacroValueEncoder$Extension'
 # ENV warpscript.extension.debug io.warp10.script.ext.debug.DebugWarpScriptExtension
@@ -20,5 +23,5 @@ ADD https://dl.bintray.com/senx/maven/io/warp10/warp10-ext-protobuf/1.1.0-uberja
 
 ADD ./images/warp10/s6 /etc
 ADD ./warpscript /usr/local/share/warpscript
-
+ADD ./images/warp10/static.tokens /
 CMD /init

--- a/images/warp10/s6/cont-init.d/00-create-directories
+++ b/images/warp10/s6/cont-init.d/00-create-directories
@@ -15,3 +15,8 @@ ensureDir "$WARP10_DATA_DIR/conf"
 ensureDir "$WARP10_DATA_DIR/data/leveldb"
 ensureDir "$WARP10_DATA_DIR/data/datalog"
 ensureDir "$WARP10_DATA_DIR/data/datalog_done"
+
+ensureDir "$SENSISION_DATA_DIR"
+ensureDir "$SENSISION_DATA_DIR/logs"
+ensureDir "$SENSISION_DATA_DIR/conf"
+ensureDir "/var/run/sensision"

--- a/images/warp10/s6/cont-init.d/20-install-config
+++ b/images/warp10/s6/cont-init.d/20-install-config
@@ -10,5 +10,5 @@ for path in $WARP10_CONF_TEMPLATES/*; do
 done
 
 echo "Installing sensision config"
-cp ${SENSISION_HOME}/templates/sensision.template $SENSISION_DATA_DIR/conf/sensision.conf
+cp ${SENSISION_HOME}/templates/sensision.template ${SENSISION_DATA_DIR}/conf/sensision.conf
 cp ${SENSISION_HOME}/templates/log4j.properties.template ${SENSISION_DATA_DIR}/conf/log4j.properties

--- a/images/warp10/s6/cont-init.d/20-install-config
+++ b/images/warp10/s6/cont-init.d/20-install-config
@@ -1,5 +1,6 @@
 #!/usr/bin/with-contenv sh
 
+echo "Installing warp 10 config"
 for path in $WARP10_CONF_TEMPLATES/*; do
     name="$(basename $path .template)"
     if [ ! -f "$WARP10_DATA_DIR/conf/$name" ]; then
@@ -7,3 +8,7 @@ for path in $WARP10_CONF_TEMPLATES/*; do
         echo "Copied $name to $WARP10_DATA_DIR/conf/$name"
     fi
 done
+
+echo "Installing sensision config"
+cp ${SENSISION_HOME}/templates/sensision.template $SENSISION_DATA_DIR/conf/sensision.conf
+cp ${SENSISION_HOME}/templates/log4j.properties.template ${SENSISION_DATA_DIR}/conf/log4j.properties

--- a/images/warp10/s6/cont-init.d/30-create-symlinks
+++ b/images/warp10/s6/cont-init.d/30-create-symlinks
@@ -15,3 +15,9 @@ ensure_link "$WARP10_HOME/etc/conf.d" "$WARP10_DATA_DIR/conf"
 ensure_link "$WARP10_HOME/leveldb" "$WARP10_DATA_DIR/data/leveldb"
 ensure_link "$WARP10_HOME/datalog" "$WARP10_DATA_DIR/data/datalog"
 ensure_link "$WARP10_HOME/datalog_done" "$WARP10_DATA_DIR/data/datalog_done"
+
+ensure_link "$SENSISION_HOME/etc" "${SENSISION_DATA_DIR}/conf"
+ensure_link "$SENSISION_HOME/logs" "${SENSISION_DATA_DIR}/logs"
+ensure_link /var/run/sensision/metrics ${SENSISION_HOME}/metrics
+ensure_link /var/run/sensision/targets ${SENSISION_HOME}/targets
+ensure_link /var/run/sensision/queued ${SENSISION_HOME}/queued

--- a/images/warp10/s6/cont-init.d/70-bootstrap-sensision
+++ b/images/warp10/s6/cont-init.d/70-bootstrap-sensision
@@ -1,0 +1,9 @@
+#!/usr/bin/with-contenv sh
+
+chmod 1733 "$SENSISION_HOME/metrics"
+chmod 1733 "$SENSISION_HOME/targets"
+chmod 700 "$SENSISION_HOME/queued"
+
+sed -i 's/@warp:WriteToken@/'"writeTokenStatic"'/' $SENSISION_DATA_DIR/conf/sensision.conf
+sed -i -e "s_^sensision\.home.*_sensision\.home = ${SENSISION_HOME}_" $SENSISION_DATA_DIR/conf/sensision.conf
+sed -i -e 's_^sensision\.qf\.url\.default.*_sensision\.qf\.url\.default=http://127.0.0.1:4802/api/v0/update_' $SENSISION_DATA_DIR/conf/sensision.conf

--- a/images/warp10/s6/services.d/sensision/run
+++ b/images/warp10/s6/services.d/sensision/run
@@ -1,0 +1,26 @@
+#!/usr/bin/with-contenv sh
+
+JAVA="/usr/bin/java"
+JAVA_OPTS=""
+
+VERSION=1.0.21
+SENSISION_CONFIG=${SENSISION_DATA_DIR}/conf/sensision.conf
+SENSISION_JAR=${SENSISION_HOME}/bin/sensision-${VERSION}.jar
+SENSISION_CP=${SENSISION_HOME}/etc:${SENSISION_JAR}
+SENSISION_CLASS=io.warp10.sensision.Main
+export MALLOC_ARENA_MAX=1
+
+if [ -z "$SENSISION_HEAP" ]; then
+    SENSISION_HEAP=64m
+fi
+
+SENSISION_CMD="${JAVA} ${JAVA_OPTS} -Xmx${SENSISION_HEAP} -Dsensision.server.port=0 ${SENSISION_OPTS} -Dsensision.config=${SENSISION_CONFIG} -cp ${SENSISION_CP} ${SENSISION_CLASS}"
+
+if [ -n "$ENABLE_SENSISION" ]; then
+    echo "Starting Sensision with $SENSISION_CMD ..."
+    exec $SENSISION_CMD | tee -a ${SENSISION_HOME}/logs/sensision.log
+else
+    echo "Sensision is disabled"
+    # wait indefinitely
+    exec tail -f /dev/null
+fi

--- a/images/warp10/s6/services.d/warp10/run
+++ b/images/warp10/s6/services.d/warp10/run
@@ -1,13 +1,37 @@
 #!/usr/bin/with-contenv sh
 
+export SENSISIONID=warp10
+export MALLOC_ARENA_MAX=1
+
 JAVA="/usr/bin/java"
 WARP10_JAR=${WARP10_HOME}/bin/warp10-${WARP10_VERSION}.jar
 WARP10_CLASS=io.warp10.standalone.Warp
 WARP10_CP="${WARP10_HOME}/etc:${WARP10_JAR}:${WARP10_HOME}/lib/*"
 WARP10_CONFIG_DIR="$WARP10_DATA_DIR/conf"
 CONFIG_FILES="$(find ${WARP10_CONFIG_DIR} -not -path "*/\.*" -name "*.conf" | sort | tr '\n' ' ' 2> /dev/null)"
+LOG4J_CONF=${WARP10_HOME}/etc/log4j.properties
 
-WARP10_CMD="${JAVA} ${JAVA_OPTS} -cp ${WARP10_CP} ${WARP10_CLASS} ${CONFIG_FILES}"
+if [ -z "$WARP10_HEAP" ]; then
+    WARP10_HEAP=1g
+fi
+
+if [ -z "$WARP10_HEAP_MAX" ]; then
+    WARP10_HEAP_MAX=1g
+fi
+
+JAVA_OPTS="-Djava.awt.headless=true -Xms${WARP10_HEAP} -Xmx${WARP10_HEAP_MAX} -XX:+UseG1GC ${JAVA_OPTS}"
+
+SENSISION_OPTS=
+if [ -n "$ENABLE_SENSISION" ]; then
+    _SENSISION_LABELS=
+    # Expects a comma seperated list of key=value ex key=value,foo=bar
+    if [ -n "$SENSISION_LABELS" ]; then
+        _SENSISION_LABELS="-Dsensision.default.labels=$SENSISION_LABELS"
+    fi
+    SENSISION_OPTS="-Dsensision.server.port=0 ${_SENSISION_LABELS} -Dsensision.events.dir=/var/run/sensision/metrics -Dfile.encoding=UTF-8"
+fi
+
+WARP10_CMD="${JAVA} -Dlog4j.configuration=file:${LOG4J_CONF} ${JAVA_OPTS} ${SENSISION_OPTS} -cp ${WARP10_CP} ${WARP10_CLASS} ${CONFIG_FILES}"
 
 echo "Starting Warp 10 with $WARP10_CMD ..."
 exec $WARP10_CMD | tee -a ${WARP10_HOME}/logs/warp10.log

--- a/images/warp10/static.tokens
+++ b/images/warp10/static.tokens
@@ -1,0 +1,9 @@
+token.write.0.name=writeTokenStatic
+token.write.0.producer=42424242-4242-4242-4242-424242424242
+token.write.0.owner=42424242-4242-4242-4242-424242424242
+token.write.0.app=utapi
+
+
+token.read.0.name=readTokenStatic
+token.read.0.owner=42424242-4242-4242-4242-424242424242
+token.read.0.app=utapi


### PR DESCRIPTION
- Adds static.tokens from the federation image
- Adds a disabled by default sensision metrics collector
- Exposes some new tunables for warp10
- Adds some missing flags used in the upstream warp10 init
