### PR TITLE
bf(S3C-3514): Add missing call to responseLoggerMiddleware in errorMiddleware

### DIFF
--- a/libV2/server/middleware.js
+++ b/libV2/server/middleware.js
@@ -44,6 +44,17 @@ function loggerMiddleware(req, res, next) {
     return next();
 }
 
+function responseLoggerMiddleware(req, res, next) {
+    const info = {
+        httpCode: res.statusCode,
+        httpMessage: res.statusMessage,
+    };
+    req.logger.end('finished handling request', info);
+    if (next !== undefined) {
+        next();
+    }
+}
+
 // next is purposely not called as all error responses are handled here
 // eslint-disable-next-line no-unused-vars
 function errorMiddleware(err, req, res, next) {
@@ -70,15 +81,7 @@ function errorMiddleware(err, req, res, next) {
             message,
         },
     });
-}
-
-function responseLoggerMiddleware(req, res, next) {
-    const info = {
-        httpCode: res.statusCode,
-        httpMessage: res.statusMessage,
-    };
-    req.logger.end('finished handling request', info);
-    return next();
+    responseLoggerMiddleware(req, res);
 }
 
 // eslint-disable-next-line no-unused-vars

--- a/tests/utils/v2Data/request.js
+++ b/tests/utils/v2Data/request.js
@@ -7,6 +7,10 @@ class ExpressResponseStub {
         this._redirect = null;
     }
 
+    get statusCode() {
+        return this._status;
+    }
+
     status(code) {
         this._status = code;
         return this;


### PR DESCRIPTION
`responseLoggerMiddleware` is moved upward so it defines before `errorMiddleware` to avoid a linting error