### PR TITLE
INTEGRATION [PR#821 > development/8.1] bf(S3C-3514): Add missing call to responseLoggerMiddleware in errorMiddleware

### DIFF
--- a/libV2/server/middleware.js
+++ b/libV2/server/middleware.js
@@ -44,6 +44,17 @@ function loggerMiddleware(req, res, next) {
     return next();
 }
 
+function responseLoggerMiddleware(req, res, next) {
+    const info = {
+        httpCode: res.statusCode,
+        httpMessage: res.statusMessage,
+    };
+    req.logger.end('finished handling request', info);
+    if (next !== undefined) {
+        next();
+    }
+}
+
 // next is purposely not called as all error responses are handled here
 // eslint-disable-next-line no-unused-vars
 function errorMiddleware(err, req, res, next) {
@@ -70,15 +81,7 @@ function errorMiddleware(err, req, res, next) {
             message,
         },
     });
-}
-
-function responseLoggerMiddleware(req, res, next) {
-    const info = {
-        httpCode: res.statusCode,
-        httpMessage: res.statusMessage,
-    };
-    req.logger.end('finished handling request', info);
-    return next();
+    responseLoggerMiddleware(req, res);
 }
 
 // eslint-disable-next-line no-unused-vars

--- a/tests/unit/v2/server/testMiddleware.js
+++ b/tests/unit/v2/server/testMiddleware.js
@@ -37,7 +37,7 @@ describe('Test middleware', () => {
         );
     });
 
-    describe('test errorMiddleware', () => {\
+    describe('test errorMiddleware', () => {
         let req;
         let resp;
 
@@ -46,7 +46,7 @@ describe('Test middleware', () => {
             resp = new ExpressResponseStub();
         });
 
-        it('should set a default code and message', next => {
+        it('should set a default code and message', () => {
             middleware.errorMiddleware({}, req, resp);
             assert.strictEqual(resp._status, 500);
             assert.deepStrictEqual(resp._body, {

--- a/tests/unit/v2/server/testMiddleware.js
+++ b/tests/unit/v2/server/testMiddleware.js
@@ -37,15 +37,17 @@ describe('Test middleware', () => {
         );
     });
 
-    describe('test errorMiddleware', () => {
+    describe('test errorMiddleware', () => {\
+        let req;
         let resp;
 
         beforeEach(() => {
+            req = templateRequest();
             resp = new ExpressResponseStub();
         });
 
-        it('should set a default code and message', () => {
-            middleware.errorMiddleware({}, null, resp);
+        it('should set a default code and message', next => {
+            middleware.errorMiddleware({}, req, resp);
             assert.strictEqual(resp._status, 500);
             assert.deepStrictEqual(resp._body, {
                 error: {
@@ -56,7 +58,7 @@ describe('Test middleware', () => {
         });
 
         it('should set the correct info from an error', () => {
-            middleware.errorMiddleware({ code: 123, message: 'Hello World!', utapiError: true }, null, resp);
+            middleware.errorMiddleware({ code: 123, message: 'Hello World!', utapiError: true }, req, resp);
             assert.deepStrictEqual(resp._body, {
                 error: {
                     code: '123',
@@ -66,13 +68,23 @@ describe('Test middleware', () => {
         });
 
         it("should replace an error's message if it's internal and not in development mode", () => {
-            middleware.errorMiddleware({ code: 123, message: 'Hello World!' }, null, resp);
+            middleware.errorMiddleware({ code: 123, message: 'Hello World!' }, req, resp);
             assert.deepStrictEqual(resp._body, {
                 error: {
                     code: '123',
                     message: 'Internal Error',
                 },
             });
+        });
+
+        it('should call responseLoggerMiddleware after response', () => {
+            const spy = sinon.spy();
+            req.logger.end = spy;
+            middleware.errorMiddleware({ code: 123, message: 'Hello World!' }, req, resp);
+            assert(spy.calledOnceWith('finished handling request', {
+                httpCode: 123,
+                httpMessage: 'Hello World!',
+            }));
         });
     });
 });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #821.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-3514_add_missing_logline`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-3514_add_missing_logline
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-3514_add_missing_logline
```

Please always comment pull request #821 instead of this one.