### PR TITLE
INTEGRATION [PR#849 > development/8.1] bf(S3C=3696): Bump default java max heap to 4GiB

### DIFF
--- a/images/warp10/s6/services.d/warp10/run
+++ b/images/warp10/s6/services.d/warp10/run
@@ -16,7 +16,7 @@ if [ -z "$WARP10_HEAP" ]; then
 fi
 
 if [ -z "$WARP10_HEAP_MAX" ]; then
-    WARP10_HEAP_MAX=1g
+    WARP10_HEAP_MAX=4g
 fi
 
 JAVA_OPTS="-Djava.awt.headless=true -Xms${WARP10_HEAP} -Xmx${WARP10_HEAP_MAX} -XX:+UseG1GC ${JAVA_OPTS}"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #849.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-3696_bump_default_java_max_heap`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-3696_bump_default_java_max_heap
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-3696_bump_default_java_max_heap
```

Please always comment pull request #849 instead of this one.