### PR TITLE
INTEGRATION [PR#869 > development/8.1] bf(S3C-3725): translate listBucketMultipartUploads during migration

### DIFF
--- a/libV2/constants.js
+++ b/libV2/constants.js
@@ -96,6 +96,9 @@ const constants = {
     counterBaseValueExpiration: 86400, // 24hrs
     keyVersionSplitter: String.fromCharCode(0),
     migrationChunksize: 500,
+    migrationOpTranslationMap: {
+        listBucketMultipartUploads: 'listMultipartUploads',
+    },
 };
 
 constants.operationToResponse = constants.operations

--- a/libV2/tasks/Migrate.js
+++ b/libV2/tasks/Migrate.js
@@ -6,7 +6,12 @@ const { UtapiRecord } = require('../models');
 const config = require('../config');
 const errors = require('../errors');
 const RedisClient = require('../redis');
-const { warp10RecordType, operations: operationIds, serviceToWarp10Label } = require('../constants');
+const {
+    warp10RecordType,
+    operations: operationIds,
+    serviceToWarp10Label,
+    migrationOpTranslationMap,
+} = require('../constants');
 const {
     LoggerContext,
     now,
@@ -167,6 +172,8 @@ class MigrateTask extends BaseTask {
                     outgoingBytes = apiOp.count;
                 } else if (operationIds.includes(apiOp.op)) {
                     operations[apiOp.op] = apiOp.count;
+                } else if (migrationOpTranslationMap[apiOp.op] !== undefined) {
+                    operations[migrationOpTranslationMap[apiOp.op]] = apiOp.count;
                 } else {
                     logger.warn('dropping unknown operation', { apiOp });
                 }


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #869.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-3725_translate_listBucketMulitpartUploads_in_migrate`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-3725_translate_listBucketMulitpartUploads_in_migrate
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-3725_translate_listBucketMulitpartUploads_in_migrate
```

Please always comment pull request #869 instead of this one.