### PR TITLE
ft(S3C-3812): Add support for deletion in warp 10 client

### DIFF
--- a/tests/functional/v2/warp10/testClient.js
+++ b/tests/functional/v2/warp10/testClient.js
@@ -39,4 +39,15 @@ describe('Test Warp Client', () => {
         const res = await warp10.exec({ script: testWarpscript, params: { greeting: 'hello' } });
         assert.deepStrictEqual(res.result[0], ['OK']);
     });
+
+    it('should delete the specified time range', async () => {
+        const ev = generateFakeEvents(startTime, endTime, 100);
+        const count = await warp10.ingest({ className }, ev);
+        let fetchResp = await warp10.fetch({ className, start: endTime, stop: startTime });
+        assert.strictEqual(JSON.parse(fetchResp.result[0]).length, 1);
+        assert.strictEqual(JSON.parse(fetchResp.result[0])[0].v.length, count);
+        await warp10.delete({ className, start: startTime, end: endTime });
+        fetchResp = await warp10.fetch({ className, start: endTime, stop: startTime });
+        assert.strictEqual(JSON.parse(fetchResp.result[0]).length, 0);
+    });
 });


### PR DESCRIPTION
Adds support for deletion, along with breaking out access to the update method of the underlying client for future use.

Why not use the existing `delete` method on the @senx/warp10  client?
`dayjs` is used internally by the senx client to convert parameters, which prevents us from using microsecond precision in our delete ranges which we need.