### PR TITLE
INTEGRATION [PR#912 > development/7.10] bf(S3C-3970): Reduce scanning of unrelated events during metric calculation

### DIFF
--- a/warpscript/utapi/createCheckpoint.mc2
+++ b/warpscript/utapi/createCheckpoint.mc2
@@ -29,10 +29,6 @@
     $auth_info 'write' GET 'write_token' STORE
     $auth_info 'read' GET 'read_token' STORE
 
-    // Raise the max operations for a executing script
-    $read_token AUTHENTICATE
-    // 10000000 MAXOPS // Investigate to find worst expected case
-
     // Grab our passed nodeId, wrap in a map and store it as the variable `filterLabels`
     $operation_info 'nodeId' GET  'nodeId' STORE
     { 'node' $nodeId } 'filterLabels' STORE
@@ -48,8 +44,14 @@
     'utapi.event' 'metric_class' STORE
 
     $read_token $master_checkpoint_class $filterLabels $endTimestamp @utapi/fetchFirstRecordBefore // Fetch latest master checkpoint
-    FIRSTTICK 'startTimestamp' STORE // Grab our starting timestamp from the last checkpoint (0 if no checkpoints)
+    FIRSTTICK
+    // If we found a checkpoint, increment its timestamp
+    <% DUP 0 > %>
+    <%  1 + %> IFT
+    'startTimestamp' STORE // Grab our starting timestamp from the last checkpoint (0 if no checkpoints)
+
     // 'Using ' $startTimestamp TOSTRING + ' as startTimestamp' + LOGMSG
+    // 'Using ' $endTimestamp TOSTRING + ' as endTimestamp' + LOGMSG
     {} 'results' STORE # Create an empty map for results
 
     $fieldsToIndex
@@ -72,7 +74,7 @@
       <% // Iter over events
         'event' STORE // Store the event
         $event 4 GET @utapi/decodeEvent 'decoded' STORE
-        // 'Including event ' $decoded 'id' GET + LOGMSG
+        // 'Including event ' $event 0 GET TOSTRING + ' ' + $decoded ->JSON + LOGMSG
         $decoded KEYLIST 'eventFields' STORE // Extract and store available event fields
         $decoded 'op' GET 'operationId' STORE
 

--- a/warpscript/utapi/createSnapshot.mc2
+++ b/warpscript/utapi/createSnapshot.mc2
@@ -28,10 +28,6 @@
     $auth_info 'write' GET 'write_token' STORE
     $auth_info 'read' GET 'read_token' STORE
 
-    // Raise the max operations for a executing script
-    $read_token AUTHENTICATE
-    // 10000000 MAXOPS // Investigate to find worst expected case
-
     // Grab our passed nodeId, wrap in a map and store it as the variable `filterLabels`
     $operation_info 'nodeId' GET  'nodeId' STORE
     { 'node' $nodeId } 'filterLabels' STORE
@@ -47,8 +43,11 @@
     // Fetch latest master snapshot
     $read_token $master_snapshot_class $filterLabels $endTimestamp @utapi/fetchFirstRecordBefore
 
-    FIRSTTICK 'masterSnapshotTimestamp' STORE // Grab our ending timestamp from the last master snapshot (0 if no snapshots)
-    // $masterSnapshotTimestamp TOSTRING LOGMSG
+    FIRSTTICK
+    // If we found a snapshot, increment its timestamp so we start at the tick immediatly after
+    <% DUP 0 > %>
+    <%  1 + %> IFT
+    'masterSnapshotTimestamp' STORE // Grab our ending timestamp from the last master snapshot (0 if no snapshots)
 
     [
       "node"

--- a/warpscript/utapi/getMetricsAt.mc2
+++ b/warpscript/utapi/getMetricsAt.mc2
@@ -28,20 +28,16 @@
     JSON-> 'operation_info' STORE
     JSON-> 'auth_info' STORE
 
-  // $operation_info ->JSON LOGMSG
-
     $auth_info 'read' GET 'read_token' STORE
 
     $operation_info 'end' GET TOLONG 'endTimestamp' STORE
     $operation_info 'labels' GET 'labels' STORE
-    $operation_info 'node' GET 'nodeID' STORE
 
-    // Raise the max operations for a executing script
-    // $read_token AUTHENTICATE
-    // 10000000 MAXOPS
+    $operation_info 'node' GET 'nodeID' STORE
 
     'utapi.event' 'event_class' STORE
     'utapi.checkpoint' 'checkpoint_class' STORE
+    'utapi.checkpoint.master' 'master_checkpoint_class' STORE
     'utapi.snapshot' 'snapshot_class' STORE
     'utapi.repair.correction' 'correction_class' STORE
     'utapi.repair.reindex' 'reindex_class' STORE
@@ -58,34 +54,52 @@
 
     // Find all nodes containing snapshots
     'load_snapshots' SECTION
-    [
-      $read_token
-      $snapshot_class
-      $labels
-    ] FINDSETS
-    DROP SWAP DROP
-    'node' GET
-    <% DUP ISNULL %>
-    <% DROP [] %> IFT
-    // Load the latest snapshot from each node
+
+    // Define our macro to sum the snapshots and save their timestamp
     <%
-      'value' STORE
-      // Adds the `node` label to the map
-      $labels UNMAP 'node' $value } 'filterLabels' STORE
+      DUP 7 GET
+      <%
+        @utapi/decodeRecord
+        $results @util/sumRecord
+        'results' STORE
+      %> FOREACH
+      $snapshots SWAP
+      DUP 0 GET DUP 'tick' STORE SWAP
+      // Get the 3rd element from the list
+      // Get the last element from resulting list
+      // Get 'node' from resulting map
+      2 GET DUP SIZE 1 - GET 'node' GET
+      PUT DROP
+      [ $tick NaN NaN NaN NULL ]
+    %> 'sumSnapshot' STORE
 
-      $read_token $snapshot_class $filterLabels $endTimestamp @utapi/fetchFirstRecordBefore
-      DUP FIRSTTICK $snapshots SWAP $value PUT DROP
-      VALUES 0 GET @utapi/decodeRecord
-      $results @util/sumRecord 'results' STORE
-    %> FOREACH
+    // Fetch the last snapshot for every node
+    {
+      'token' $read_token
+      'class' $snapshot_class
+      'labels' $labels UNMAP }
+      'end' $endTimestamp
+      'count' 1
+    } FETCH
 
-    // $snapshots ->JSON LOGMSG
-    // $results ->JSON LOGMSG
+    // Apply our macro over the snapshots
+    // Drop the result as we don't need it
+    [
+      SWAP
+      [ 'node' ]
+      $sumSnapshot MACROREDUCER
+      true
+    ] REDUCE
+    DROP
+
+    'load_checkpoints' SECTION
 
     {} 'checkpoints' STORE
 
+    // 'snapshots: ' $snapshots ->JSON + LOGMSG
+    // 'results: ' $results ->JSON + LOGMSG
+
     // Find all nodes containing checkpoints
-    'load_checkpoints' SECTION
     [
       $read_token
       $checkpoint_class
@@ -95,53 +109,74 @@
     'node' GET
     <% DUP ISNULL %>
     <% DROP [] %> IFT
-    // Load checkpoints from each node
+
+    [ SWAP // Push a mark onto the stack
     <%
       'key' STORE
       // Adds the `node` label to the map
       $labels UNMAP 'node' $key } 'filterLabels' STORE
 
-      -1 'checkpointTimestamp' STORE
-
       // Get the timestamp of the corresponding snapshot if it exists otherwise use 0
       $snapshots $key GET
       <% DUP TYPEOF 'LONG' != %>
-      <% DROP 0 %> IFT
+      <% DROP -1 %> IFT
       'startTimestamp' STORE
       {
         'token' $read_token
         'class' $checkpoint_class
         'labels' $filterLabels
         'end' $endTimestamp
-        'start' $startTimestamp
+        'start' $startTimestamp 1 +
       } FETCH
 
-      <% // Handle multiple GTS
 
-        DUP LASTTICK
-        <% DUP $checkpointTimestamp > %>
-        <% 'checkpointTimestamp' STORE %>
-        <% DROP %> IFTE
-
-
-        // DUP ->JSON LOGMSG
-        VALUES
-        <% // For each checkpoint
-          @utapi/decodeRecord
-          // DUP 'Loaded checkpoint ' SWAP ->JSON + LOGMSG
-          $results @util/sumRecord 'results' STORE
-        %> FOREACH
-      %> FOREACH
-
-      // Only add an entry if a checkpoint is found
-      <% $checkpointTimestamp -1 > %>
-      <%
-        $checkpoints $checkpointTimestamp $key PUT DROP
-      %> IFT
     %> FOREACH
 
-    // $checkpoints ->JSON LOGMSG
-    // $results ->JSON LOGMSG
+    ]
+    FLATTEN
+
+    <%
+      DUP 7 GET
+      <%
+        @utapi/decodeRecord
+        $results @util/sumRecord
+        'results' STORE
+      %> FOREACH
+      [ SWAP 0 GET NaN NaN NaN NULL ]
+    %> 'sumCheckpoint' STORE
+
+    [
+      SWAP
+      [ 'node' ]
+      $sumCheckpoint MACROREDUCER
+      true
+    ] REDUCE
+    DROP
+
+    // 'results: ' $results ->JSON + LOGMSG
+
+    // 'loading master checkpoints' LOGMSG
+
+    // Load the most recent master checkpoint before our target timestamp from each node
+    {} 'masterCheckpoints' STORE
+    {
+      'token' $read_token
+      'class' $master_checkpoint_class
+      'labels' {}
+      'end' $endTimestamp
+      'count' 1
+    }
+    FETCH
+    <%
+      $masterCheckpoints SWAP
+      DUP LASTTICK SWAP
+      LABELS 'node' GET
+      PUT DROP
+    %> FOREACH
+
+    // 'loaded master checkpoints: '
+    // $masterCheckpoints ->JSON + LOGMSG
+    // $labels ->JSON LOGMSG
 
     // Find all nodes containing events
     'load_events' SECTION
@@ -158,24 +193,19 @@
     <%
       'key' STORE
 
-      // Get the timestamp of the latest checkpoint for the node if it exists
-      // otherwise look for a snapshot
-      // If all else fails use 0
-      $checkpoints $key GET
+      // Get the timestamp of the master checkpoint for the node if it exists
+      // If no master checkpoint exists for a node then we can infer that no
+      // snapshots exists for that node as well, and we must start at 0
+      $masterCheckpoints $key GET
       <% DUP TYPEOF 'LONG' != %>
-      <%
-        DROP
-        $snapshots $key GET
-        <% DUP TYPEOF 'LONG' != %>
-        <% DROP 0 %> IFT
-      %> IFT
+      <% DROP -1 %> IFT
       'startTimestamp' STORE
       {
         'token' $read_token
         'class' $event_class
         'labels' { 'node' $key }
         'end' $endTimestamp
-        'start' $startTimestamp
+        'start' $startTimestamp 1 +
       } FETCH
       <% // Handle multiple GTS
         VALUES
@@ -194,7 +224,6 @@
 
           <% $passed %>
           <%
-            // $event ->JSON LOGMSG
             $results
             'objD' $event 'objD' 0 @util/getDefault @util/sumField
             'sizeD' $event 'sizeD' 0 @util/getDefault @util/sumField
@@ -233,14 +262,14 @@
       // Get the timestamp of the corresponding snapshot if it exists otherwise use 0
       $snapshots $key GET
       <% DUP TYPEOF 'LONG' != %>
-      <% DROP 0 %> IFT
+      <% DROP -1 %> IFT
       'startTimestamp' STORE
       {
         'token' $read_token
         'class' $correction_class
         'labels' $filterLabels
         'end' $endTimestamp
-        'start' $startTimestamp
+        'start' $startTimestamp 1 +
       } FETCH
 
       <% // Handle multiple GTS

--- a/warpscript/utapi/repairRecords.mc2
+++ b/warpscript/utapi/repairRecords.mc2
@@ -41,7 +41,11 @@
     'utapi.repair.event' 'metric_class' STORE
 
     $read_token $master_repair_class $filterLabels $endTimestamp @utapi/fetchFirstRecordBefore // Fetch latest master repair
-    FIRSTTICK 'startTimestamp' STORE // Grab our starting timestamp from the last repair (0 if no repairs)
+    FIRSTTICK
+    // If we found a repair, increment its timestamp so we start at the tick immediatly after
+    <% DUP 0 > %>
+    <%  1 + %> IFT
+    'startTimestamp' STORE // Grab our starting timestamp from the last repair (0 if no repairs)
     // 'Using ' $startTimestamp TOSTRING + ' as startTimestamp' + LOGMSG
 
     {} 'results' STORE # Create an empty map for results


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #912.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/bugfix/S3C-3970_reduce_scanning_of_event_during_query`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/bugfix/S3C-3970_reduce_scanning_of_event_during_query
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/bugfix/S3C-3970_reduce_scanning_of_event_during_query
```

Please always comment pull request #912 instead of this one.