### PR TITLE
bugfix: S3C-3620 don't raise exception on ioredis client error

### DIFF
--- a/libV2/redis.js
+++ b/libV2/redis.js
@@ -103,7 +103,9 @@ class RedisClient extends EventEmitter {
 
     _onError(error) {
         moduleLogger.error('error connecting to redis', { error });
-        this.emit('error', error);
+        if (this.listenerCount('error') > 0) {
+            this.emit('error', error);
+        }
     }
 
     _createCommandTimeout() {

--- a/tests/functional/v2/cache/testRedisBackend.js
+++ b/tests/functional/v2/cache/testRedisBackend.js
@@ -9,8 +9,6 @@ const startTime = new Date().getTime();
 const endTime = startTime + 30000; // Add 30 seconds;
 const testValues = generateFakeEvents(startTime, endTime, 50);
 
-describe('test', async () => true);
-
 describe('Test cache redis backend', () => {
     let cache;
     let prefix;

--- a/tests/unit/v2/RedisClient.js
+++ b/tests/unit/v2/RedisClient.js
@@ -1,0 +1,21 @@
+const RedisClient = require('../../../libV2/redis');
+
+describe('Test RedisClient', () => {
+    let client;
+
+    beforeEach(() => {
+        client = new RedisClient({});
+        client.connect();
+    });
+
+    afterEach(() => client.disconnect());
+
+    it('should not raise exception if redis backend emits error without a listener', () => {
+        client._redis.emit('error', new Error('OOPS'));
+    });
+
+    it('should be able to listen to redis backend errors', done => {
+        client.on('error', () => done());
+        client._redis.emit('error', new Error('OOPS'));
+    });
+});


### PR DESCRIPTION
 When ioredis emits an error (e.g. connection issue), instead of
 unconditionally raising it in the RedisClient wrapper, only raise it
 if there is at least one listener for the 'error' event.
 
 Some users of RedisClient (v2 cache and reindex tasks) do not set a
 listener on error events, resulting in assertions being raised and
 process crash.
