### PR TITLE
INTEGRATION [PR#928 > development/8.1] bugfix: S3C-3620 don't raise exception on ioredis client error

### DIFF
--- a/libV2/redis.js
+++ b/libV2/redis.js
@@ -103,7 +103,9 @@ class RedisClient extends EventEmitter {
 
     _onError(error) {
         moduleLogger.error('error connecting to redis', { error });
-        this.emit('error', error);
+        if (this.listenerCount('error') > 0) {
+            this.emit('error', error);
+        }
     }
 
     _createCommandTimeout() {

--- a/tests/functional/v2/cache/testRedisBackend.js
+++ b/tests/functional/v2/cache/testRedisBackend.js
@@ -9,8 +9,6 @@ const startTime = new Date().getTime();
 const endTime = startTime + 30000; // Add 30 seconds;
 const testValues = generateFakeEvents(startTime, endTime, 50);
 
-describe('test', async () => true);
-
 describe('Test cache redis backend', () => {
     let cache;
     let prefix;

--- a/tests/unit/v2/RedisClient.js
+++ b/tests/unit/v2/RedisClient.js
@@ -1,0 +1,21 @@
+const RedisClient = require('../../../libV2/redis');
+
+describe('Test RedisClient', () => {
+    let client;
+
+    beforeEach(() => {
+        client = new RedisClient({});
+        client.connect();
+    });
+
+    afterEach(() => client.disconnect());
+
+    it('should not raise exception if redis backend emits error', () => {
+        client._redis.emit('error', new Error('OOPS'));
+    });
+
+    it('should be able to listen to redis backend errors', done => {
+        client.on('error', () => done());
+        client._redis.emit('error', new Error('OOPS'));
+    });
+});


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #928.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-3620-avoidCrashOnRedisError`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-3620-avoidCrashOnRedisError
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-3620-avoidCrashOnRedisError
```

Please always comment pull request #928 instead of this one.