### PR TITLE
bugfix: S3C-4035 increase CI worker mem request

### DIFF
--- a/eve/workers/pod.yml
+++ b/eve/workers/pod.yml
@@ -13,7 +13,7 @@ spec:
     resources:
       requests:
         cpu: 500m
-        memory: 1Gi
+        memory: 3Gi
       limits:
         cpu: "2"
         memory: 3Gi


### PR DESCRIPTION
Increase the memory request of CI worker pods from 1G to 3G (limit is
still 3G)