### PR TITLE
INTEGRATION [PR#952 > development/8.1] bugfix: S3C-4035 increase CI worker mem request

### DIFF
--- a/eve/workers/pod.yml
+++ b/eve/workers/pod.yml
@@ -13,7 +13,7 @@ spec:
     resources:
       requests:
         cpu: 500m
-        memory: 1Gi
+        memory: 3Gi
       limits:
         cpu: "2"
         memory: 3Gi


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #952.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-4035-increasePodLimits`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-4035-increasePodLimits
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-4035-increasePodLimits
```

Please always comment pull request #952 instead of this one.