### PR TITLE
INTEGRATION [PR#968 > development/8.1] bf(S3C-4049): Call delete in slices rather than once

### DIFF
--- a/libV2/constants.js
+++ b/libV2/constants.js
@@ -99,6 +99,7 @@ const constants = {
     migrationOpTranslationMap: {
         listBucketMultipartUploads: 'listMultipartUploads',
     },
+    expirationChunkDuration: 900000000, // 15 minutes in microseconds
 };
 
 constants.operationToResponse = constants.operations

--- a/libV2/utils/timestamp.js
+++ b/libV2/utils/timestamp.js
@@ -42,8 +42,37 @@ function now() {
     return Date.now() * 1000;
 }
 
+/**
+ * Slice the time range represented by the passed timestamps
+ * into slices of at most `step` duration.
+ *
+ * Both `start` and `end` are included in the returned slices.
+ * Slice timestamps are inclusive and non overlapping.
+ *
+ * For example sliceTimeRange(0, 5, 2) will yield
+ * [0, 1]
+ * [2, 3]
+ * [4, 5]
+ *
+ * @param {Number} start
+ * @param {Number} end
+ * @param {Number} step
+ */
+
+function* sliceTimeRange(start, end, step) {
+    let spos = start;
+    let epos = start + step - 1;
+    while (epos < end) {
+        yield [spos, epos];
+        spos += step;
+        epos += step;
+    }
+    yield [spos, end];
+}
+
 module.exports = {
     convertTimestamp,
     InterpolatedClock,
     now,
+    sliceTimeRange,
 };

--- a/tests/functional/softLimit/testSoftLimit.js
+++ b/tests/functional/softLimit/testSoftLimit.js
@@ -1,11 +1,11 @@
 const assert = require('assert');
 const sinon = require('sinon');
-const uuid = require('uuid');
 
 const { clients: warp10Clients } = require('../../../libV2/warp10');
 const { MonitorDiskUsage } = require('../../../libV2/tasks');
 const { UtapiMetric } = require('../../../libV2/models');
 const { now } = require('../../../libV2/utils');
+const { expirationChunkDuration } = require('../../../libV2/constants');
 
 const { fetchRecords } = require('../../utils/v2Data');
 
@@ -13,23 +13,20 @@ const { fetchRecords } = require('../../utils/v2Data');
 describe('Test MonitorDiskUsage soft limit', function () {
     this.timeout(30000);
     let task;
-    let path;
 
     beforeEach(async () => {
-        path = `/tmp/diskusage-${uuid.v4()}`;
         task = new MonitorDiskUsage({ warp10: warp10Clients });
         await task.setup();
-        task._path = path;
-        task._enabled = true;
+        task._expirationEnabled = true;
+        task._program.leader = true;
     });
 
-    afterEach(() => {
+    afterEach(async () => {
         sinon.restore();
+        await warp10Clients[0].delete({ className: 'utapi.event', start: 0, end: Date.now() * 1000 });
     });
 
     it('should delete metrics older than the retention period', async () => {
-        task._expirationEnabled = true;
-        task._program.leader = true;
         task._metricRetentionMicroSecs = 0; // Force it to expire everything older than the given timestamp
         const expireSpy = sinon.spy(task, '_expireMetrics');
         const deleteStub = sinon.spy(task._warp10Clients[0], 'delete');
@@ -47,6 +44,49 @@ describe('Test MonitorDiskUsage soft limit', function () {
             {
                 className: '~.*',
                 start: timestamp - 1, // start is not inclusive
+                end: timestamp,
+            },
+        ));
+
+        const series = await fetchRecords(
+            task._warp10Clients[0],
+            'utapi.event',
+            { },
+            { end: timestamp + 2, count: 100 },
+            '@utapi/decodeEvent',
+        );
+        assert.strictEqual(series[0].values.length, 1);
+    });
+
+    it('should chunk deletion range into expirationChunkDuration slices', async () => {
+        task._metricRetentionMicroSecs = 0; // Force it to expire everything older than the given timestamp
+        const expireSpy = sinon.spy(task, '_expireMetrics');
+        const deleteStub = sinon.spy(task._warp10Clients[0], 'delete');
+
+        const timestamp = now();
+
+        // Write an event older than the maximum chunk duration to ensure we produce 2 calls
+        const recordTimestamp = timestamp - expirationChunkDuration;
+
+        await task._warp10Clients[0].ingest({ className: 'utapi.event' }, [
+            new UtapiMetric({ timestamp: recordTimestamp, bucket: 'foo' }),
+            new UtapiMetric({ timestamp: timestamp + 1, bucket: 'foo' }),
+        ]);
+
+        await task._execute(timestamp);
+        assert(expireSpy.calledOnce);
+        assert(deleteStub.calledTwice);
+        assert(deleteStub.firstCall.calledWithExactly(
+            {
+                className: '~.*',
+                start: recordTimestamp - 1,
+                end: timestamp - 2,
+            },
+        ));
+        assert(deleteStub.secondCall.calledWithExactly(
+            {
+                className: '~.*',
+                start: timestamp - 1,
                 end: timestamp,
             },
         ));

--- a/tests/unit/v2/utils/testSliceTimeRange.js
+++ b/tests/unit/v2/utils/testSliceTimeRange.js
@@ -1,0 +1,98 @@
+const assert = require('assert');
+
+const { sliceTimeRange } = require('../../../../libV2/utils');
+
+const testCases = [
+    {
+        start: 0,
+        end: 5,
+        step: 1,
+        expected: [
+            [0, 0],
+            [1, 1],
+            [2, 2],
+            [3, 3],
+            [4, 4],
+            [5, 5],
+        ],
+    },
+    {
+        start: 0,
+        end: 10,
+        step: 2,
+        expected: [
+            [0, 1],
+            [2, 3],
+            [4, 5],
+            [6, 7],
+            [8, 9],
+            [10, 10],
+        ],
+    },
+    {
+        start: 0,
+        end: 10,
+        step: 3,
+        expected: [
+            [0, 2],
+            [3, 5],
+            [6, 8],
+            [9, 10],
+        ],
+    },
+    {
+        start: 0,
+        end: 10,
+        step: 4,
+        expected: [
+            [0, 3],
+            [4, 7],
+            [8, 10],
+        ],
+    },
+    {
+        start: 0,
+        end: 10,
+        step: 5,
+        expected: [
+            [0, 4],
+            [5, 9],
+            [10, 10],
+        ],
+    },
+    {
+        start: 0,
+        end: 10,
+        step: 6,
+        expected: [
+            [0, 5],
+            [6, 10],
+        ],
+    },
+    {
+        start: 0,
+        end: 10,
+        step: 11,
+        expected: [
+            [0, 10],
+        ],
+    },
+];
+
+
+describe('Test sliceTimeRange', () => {
+    testCases.forEach(testCase => {
+        const {
+            start, end, step, expected,
+        } = testCase;
+        it(`should correctly slice range ${start}-${end} with step ${step}`, () => {
+            const results = [];
+            // eslint-disable-next-line no-restricted-syntax
+            for (const item of sliceTimeRange(start, end, step)) {
+                results.push(item);
+            }
+
+            assert.deepStrictEqual(results, expected);
+        });
+    });
+});


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #968.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-4049_call_delete_in_slices_rather_than_once`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-4049_call_delete_in_slices_rather_than_once
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-4049_call_delete_in_slices_rather_than_once
```

Please always comment pull request #968 instead of this one.