### PR TITLE
bf(S3C-4085): Don't try to translate resources if auth has failed

### DIFF
--- a/eve/workers/mocks/vault/vault.js
+++ b/eve/workers/mocks/vault/vault.js
@@ -3,15 +3,32 @@ const url = require('url');
 
 const port = process.env.VAULT_PORT || 8500;
 
+const unauthResp = {
+    ErrorResponse: {
+        $: {
+            xmlns: 'https://iam.amazonaws.com/doc/2010-05-08/',
+        },
+        Error: {
+            Code: 'InvalidAccessKeyId',
+            Message: 'The AWS access key Id you provided does not exist in our records.',
+        },
+        RequestId: '97f22e2dba45bca2a5cd:fb375c22ed4ea7500691',
+    },
+};
+
+
 class Vault {
     constructor() {
         this._server = null;
     }
 
     static _onRequest(req, res) {
-        res.writeHead(200);
         const { query } = url.parse(req.url, true);
-        if (query.Action === 'AccountsCanonicalIds') {
+        if (query.accessKey === 'invalidKey') {
+            res.writeHead(403);
+            res.write(JSON.stringify(unauthResp));
+        } else if (query.Action === 'AccountsCanonicalIds') {
+            res.writeHead(200);
             let body;
             if (Array.isArray(query.accountIds)) {
                 body = query.accountIds.map(id => ({

--- a/libV2/vault.js
+++ b/libV2/vault.js
@@ -164,6 +164,9 @@ async function authenticateRequest(request, action, level, resources) {
 
 async function translateAndAuthorize(request, action, level, resources) {
     const [authed, authorizedResources] = await authenticateRequest(request, action, level, resources);
+    if (!authed) {
+        return [authed];
+    }
     const translated = await translateResourceIds(level, authorizedResources, request.logger.logger);
     return [authed, translated];
 }

--- a/tests/functional/v2/server/testListMetrics.js
+++ b/tests/functional/v2/server/testListMetrics.js
@@ -28,7 +28,7 @@ const emptyOperationsResponse = Object.values(operationToResponse)
         return prev;
     }, {});
 
-async function listMetrics(level, resources, start, end) {
+async function listMetrics(level, resources, start, end, force403 = false) {
     const body = {
         timeRange: [start, end],
         [level]: resources,
@@ -46,7 +46,7 @@ async function listMetrics(level, resources, start, end) {
     };
 
     const credentials = {
-        accessKeyId: 'accessKey1',
+        accessKeyId: force403 ? 'invalidKey' : 'accessKey1',
         secretAccessKey: 'verySecretKey1',
     };
 
@@ -201,5 +201,10 @@ describe('Test listMetric', function () {
         assert.deepStrictEqual(accountMetric.numberOfObjects, [0, 0]);
         assert.deepStrictEqual(accountMetric.incomingBytes, 0);
         assert.deepStrictEqual(accountMetric.outgoingBytes, 0);
+    });
+
+    it('should return a 403 if unauthorized', async () => {
+        const resp = await listMetrics('buckets', ['test'], getTs(-1), getTs(1), true);
+        assert.strictEqual(resp.statusCode, 403);
     });
 });


### PR DESCRIPTION
resource ids were still being translated after authorization had failed, resulting in an exception