### PR TITLE
INTEGRATION [PR#1002 > development/7.10] bf(S3C-4137): Add operationId translsation to ingestion route for v1 …

### DIFF
--- a/libV2/constants.js
+++ b/libV2/constants.js
@@ -99,6 +99,9 @@ const constants = {
     migrationOpTranslationMap: {
         listBucketMultipartUploads: 'listMultipartUploads',
     },
+    ingestionOpTranslationMap: {
+        putDeleteMarkerObject: 'deleteObject',
+    },
     expirationChunkDuration: 900000000, // 15 minutes in microseconds
 };
 

--- a/libV2/server/API/metrics/ingestMetric.js
+++ b/libV2/server/API/metrics/ingestMetric.js
@@ -2,6 +2,7 @@ const errors = require('../../../errors');
 const { UtapiMetric } = require('../../../models');
 const { client: cacheClient } = require('../../../cache');
 const { convertTimestamp } = require('../../../utils');
+const { ingestionOpTranslationMap } = require('../../../constants');
 
 async function ingestMetric(ctx, params) {
     let metrics;
@@ -9,6 +10,7 @@ async function ingestMetric(ctx, params) {
         metrics = params.body.map(m => new UtapiMetric({
             ...m,
             timestamp: convertTimestamp(m.timestamp),
+            operationId: ingestionOpTranslationMap[m.operationId] || m.operationId,
         }));
     } catch (error) {
         throw errors.InvalidRequest;

--- a/tests/unit/v2/API/metrics/testIngestMetric.js
+++ b/tests/unit/v2/API/metrics/testIngestMetric.js
@@ -43,4 +43,19 @@ describe('Test ingestMetric', () => {
             err => err.code === 503 && err.ServiceUnavailable,
         );
     });
+
+    it('should translate putDeleteMarkerObject to deleteObject', async () => {
+        const spy = sinon.spy(cacheClient, 'pushMetric');
+        const metric = new UtapiMetric({
+            operationId: 'putDeleteMarkerObject',
+        });
+        await ingestMetric(ctx, { body: [metric.getValue()] });
+        assert.strictEqual(ctx.results.statusCode, 200);
+        assert(spy.calledWith(
+            new UtapiMetric({
+                operationId: 'deleteObject',
+                timestamp: convertTimestamp(metric.timestamp),
+            }),
+        ));
+    });
 });

--- a/tests/utils/v2Data/events.js
+++ b/tests/utils/v2Data/events.js
@@ -124,7 +124,6 @@ const eventTemplateToOperation = {
         'getObjectRetention',
         'getObjectTagging',
         'headObject',
-        'putDeleteMarkerObject',
         'putObjectAcl',
         'putObjectLegalHold',
         'putObjectRetention',


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1002.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/bugfix/S3C-4137_add_opId_translation_to_ingest_route`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/bugfix/S3C-4137_add_opId_translation_to_ingest_route
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/bugfix/S3C-4137_add_opId_translation_to_ingest_route
```

Please always comment pull request #1002 instead of this one.