### PR TITLE
INTEGRATION [PR#1013 > development/7.9] Bugfix/s3 c 4139 allow only start timestamp in req

### DIFF
--- a/libV2/server/API/metrics/listMetrics.js
+++ b/libV2/server/API/metrics/listMetrics.js
@@ -1,6 +1,6 @@
 const errors = require('../../../errors');
 const { serviceToWarp10Label, operationToResponse } = require('../../../constants');
-const { convertTimestamp, iterIfError } = require('../../../utils');
+const { convertTimestamp, iterIfError, now } = require('../../../utils');
 const { clients: warp10Clients } = require('../../../warp10');
 
 const emptyOperationsResponse = Object.values(operationToResponse)
@@ -23,9 +23,10 @@ function positiveOrZero(value) {
 async function listMetric(ctx, params) {
     const labelName = serviceToWarp10Label[params.level];
     const resources = params.body[params.level];
-    const [start, end] = params.body.timeRange
-        .map(convertTimestamp)
-        .map(v => v.toString());
+    let [start, end] = params.body.timeRange
+    if (end === undefined) {
+        end = Date.now();
+    }
 
     // A separate request will be made to warp 10 per requested resource
     const results = await Promise.all(
@@ -35,8 +36,8 @@ async function listMetric(ctx, params) {
             const res = await iterIfError(warp10Clients, warp10 => {
                 const options = {
                     params: {
-                        start,
-                        end,
+                        start: convertTimestamp(start).toString(),
+                        end: convertTimestamp(end).toString(),
                         labels,
                         node: warp10.nodeId,
                     },
@@ -80,7 +81,7 @@ async function listMetric(ctx, params) {
 
             const metric = {
                 ...result.metrics,
-                timeRange: params.body.timeRange,
+                timeRange: [ start, end ],
                 operations: {
                     ...emptyOperationsResponse,
                     ...operations,

--- a/tests/functional/v2/server/testListMetrics.js
+++ b/tests/functional/v2/server/testListMetrics.js
@@ -30,9 +30,14 @@ const emptyOperationsResponse = Object.values(operationToResponse)
 
 async function listMetrics(level, resources, start, end, force403 = false) {
     const body = {
-        timeRange: [start, end],
         [level]: resources,
     };
+
+    if (end !== undefined) {
+        body.timeRange = [start, end];
+    } else {
+        body.timeRange = [start];
+    }
 
     const headers = {
         host: 'localhost',
@@ -206,5 +211,10 @@ describe('Test listMetric', function () {
     it('should return a 403 if unauthorized', async () => {
         const resp = await listMetrics('buckets', ['test'], getTs(-1), getTs(1), true);
         assert.strictEqual(resp.statusCode, 403);
+    });
+
+    it('should use the current timestamp for "end" if it is not provided', async () => {
+        const resp = await listMetrics('buckets', ['test'], getTs(-1));
+        assert.strictEqual(resp.timeRange.length, 2);
     });
 });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1013.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.9/bugfix/S3C-4139_allow_only_start_timestamp_in_req`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.9/bugfix/S3C-4139_allow_only_start_timestamp_in_req
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.9/bugfix/S3C-4139_allow_only_start_timestamp_in_req
```

Please always comment pull request #1013 instead of this one.