### PR TITLE
S3C-3996: Reduce logging amount from s3_bucketd.py

### DIFF
--- a/lib/reindex/s3_bucketd.py
+++ b/lib/reindex/s3_bucketd.py
@@ -201,7 +201,7 @@ class BucketDClient:
 
                 # If versioned, subtract the size of the master to avoid double counting
                 if last_master is not None and obj['key'].startswith(last_master + '\x00'):
-                    _log.info('Detected versioned key: %s - subtracting master size: %i'% (
+                    _log.debug('Detected versioned key: %s - subtracting master size: %i'% (
                         obj['key'],
                         last_size,
                     ))


### PR DESCRIPTION
When reindexing versioned buckets, s3_bucketd.py logs a lot of informations. Its father, utapi-reindex, stores the entire log in memory until s3_bucketd.py stops ... or the memory limit is hit, making utapi-reindex crash.
This patch makes versioned objects detection logging less verbose.