### PR TITLE
INTEGRATION [PR#1036 > development/7.10] S3C-3996: Reduce logging amount from s3_bucketd.py

### DIFF
--- a/lib/reindex/s3_bucketd.py
+++ b/lib/reindex/s3_bucketd.py
@@ -201,7 +201,7 @@ class BucketDClient:
 
                 # If versioned, subtract the size of the master to avoid double counting
                 if last_master is not None and obj['key'].startswith(last_master + '\x00'):
-                    _log.info('Detected versioned key: %s - subtracting master size: %i'% (
+                    _log.debug('Detected versioned key: %s - subtracting master size: %i'% (
                         obj['key'],
                         last_size,
                     ))


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1036.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/bugfix/S3C-3996/reduce-reindex-logging`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/bugfix/S3C-3996/reduce-reindex-logging
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/bugfix/S3C-3996/reduce-reindex-logging
```

Please always comment pull request #1036 instead of this one.