### PR TITLE
INTEGRATION [PR#1055 > development/7.9] backport S3C-3996: Reduce logging amount from s3_bucketd.py

### DIFF
--- a/lib/reindex/s3_bucketd.py
+++ b/lib/reindex/s3_bucketd.py
@@ -195,7 +195,7 @@ class BucketDClient:
 
                 # If versioned, subtract the size of the master to avoid double counting
                 if last_master is not None and obj['key'].startswith(last_master + '\x00'):
-                    _log.info('Detected versioned key: %s - subtracting master size: %i'% (
+                    _log.debug('Detected versioned key: %s - subtracting master size: %i'% (
                         obj['key'],
                         last_size,
                     ))


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1055.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.9/bugfix/S3C-3996-backport-7.4`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.9/bugfix/S3C-3996-backport-7.4
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.9/bugfix/S3C-3996-backport-7.4
```

Please always comment pull request #1055 instead of this one.