### PR TITLE
INTEGRATION [PR#1068 > development/8.1] ft(S3C-3692): Add accountId -> canonicalId conversion for ListRecentM…

### DIFF
--- a/lib/ListMetrics.js
+++ b/lib/ListMetrics.js
@@ -124,7 +124,27 @@ class ListMetrics {
         const fifteenMinutes = 15 * 60 * 1000; // In milliseconds
         const timeRange = [start - fifteenMinutes, end];
         const datastore = utapiRequest.getDatastore();
-        async.mapLimit(resources, 5, (resource, next) => this.getMetrics(resource, timeRange, datastore, log,
+
+        // map account ids to canonical ids
+        if (this.metric === 'accounts') {
+            return this.vault.getCanonicalIds(resources, log, (err, list) => {
+                if (err) {
+                    return cb(err);
+                }
+                return async.mapLimit(list.message.body, 5,
+                    (item, next) => this.getMetrics(item.canonicalId, timeRange,
+                        datastore, log, (err, res) => {
+                            if (err) {
+                                return next(err);
+                            }
+                            return next(null, Object.assign({}, res,
+                                { accountId: item.accountId }));
+                        }),
+                    cb);
+            });
+        }
+
+        return async.mapLimit(resources, 5, (resource, next) => this.getMetrics(resource, timeRange, datastore, log,
             next), cb);
     }
 

--- a/tests/functional/server/testListMetrics.js
+++ b/tests/functional/server/testListMetrics.js
@@ -89,7 +89,7 @@ describe('Request ranges', function test() {
             timeRange, type, resource, expected,
         } = test;
         const msg = timeRange
-            ? `should handle a request range of ${timeRange[0] - timeRange[1]}ms`
+            ? `should handle a request range of ${timeRange[1] - timeRange[0]}ms`
             : 'should handle a ListRecentMetrics request';
         it(msg, done => {
             const headers = {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1068.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-3692_fix_accountid_support_in_list_metrics_js`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-3692_fix_accountid_support_in_list_metrics_js
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-3692_fix_accountid_support_in_list_metrics_js
```

Please always comment pull request #1068 instead of this one.