### PR TITLE
INTEGRATION [PR#1068 > development/8.1] ft(S3C-3692): Add accountId -> canonicalId conversion for ListRecentMetrics

### DIFF
--- a/lib/ListMetrics.js
+++ b/lib/ListMetrics.js
@@ -124,7 +124,27 @@ class ListMetrics {
         const fifteenMinutes = 15 * 60 * 1000; // In milliseconds
         const timeRange = [start - fifteenMinutes, end];
         const datastore = utapiRequest.getDatastore();
-        async.mapLimit(resources, 5, (resource, next) => this.getMetrics(resource, timeRange, datastore, log,
+
+        // map account ids to canonical ids
+        if (this.metric === 'accounts') {
+            return this.vault.getCanonicalIds(resources, log, (err, list) => {
+                if (err) {
+                    return cb(err);
+                }
+                return async.mapLimit(list.message.body, 5,
+                    (item, next) => this.getMetrics(item.canonicalId, timeRange,
+                        datastore, log, (err, res) => {
+                            if (err) {
+                                return next(err);
+                            }
+                            return next(null, Object.assign({}, res,
+                                { accountId: item.accountId }));
+                        }),
+                    cb);
+            });
+        }
+
+        return async.mapLimit(resources, 5, (resource, next) => this.getMetrics(resource, timeRange, datastore, log,
             next), cb);
     }
 

--- a/tests/functional/server/testListMetrics.js
+++ b/tests/functional/server/testListMetrics.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const { makeUtapiClientRequest } = require('../../utils/utils');
+const { makeUtapiGenericClientRequest } = require('../../utils/utils');
 const Vault = require('../../utils/mock/Vault');
 
 const MAX_RANGE_MS = (((1000 * 60) * 60) * 24) * 30; // One month.
@@ -18,34 +18,100 @@ describe('Request ranges', function test() {
 
     const tests = [
         {
-            start: 0,
-            end: ((MAX_RANGE_MS / 60) - (1000 * 60) * 15) - 1,
+            action: 'ListMetrics',
+            type: 'accounts',
+            resource: '1234567890',
+            timeRange: [
+                0,
+                ((MAX_RANGE_MS / 60) - (1000 * 60) * 15) - 1,
+            ],
+            expected: {
+                accountId: '1234567890',
+            },
         },
         {
-            start: 0,
-            end: MAX_RANGE_MS - 1,
+            action: 'ListMetrics',
+            type: 'buckets',
+            resource: 'my-bucket',
+            timeRange: [
+                0,
+                ((MAX_RANGE_MS / 60) - (1000 * 60) * 15) - 1,
+            ],
+            expected: {
+                bucketName: 'my-bucket',
+            },
         },
         {
-            start: 0,
-            end: (MAX_RANGE_MS + (1000 * 60) * 15) - 1,
+            action: 'ListMetrics',
+            type: 'buckets',
+            resource: 'my-bucket',
+            timeRange: [
+                0,
+                MAX_RANGE_MS - 1,
+            ],
+            expected: {
+                bucketName: 'my-bucket',
+            },
         },
         {
-            start: 0,
-            end: (MAX_RANGE_MS * 12) - 1,
+            action: 'ListMetrics',
+            type: 'buckets',
+            resource: 'my-bucket',
+            timeRange: [
+                0,
+                (MAX_RANGE_MS + (1000 * 60) * 15) - 1,
+            ],
+            expected: {
+                bucketName: 'my-bucket',
+            },
+        },
+        {
+            action: 'ListMetrics',
+            type: 'buckets',
+            resource: 'my-bucket',
+            timeRange: [
+                0,
+                (MAX_RANGE_MS * 12) - 1,
+            ],
+            expected: {
+                bucketName: 'my-bucket',
+            },
+        },
+        {
+            action: 'ListRecentMetrics',
+            type: 'buckets',
+            resource: 'my-bucket',
+            expected: {
+                bucketName: 'my-bucket',
+            },
+        },
+        {
+            action: 'ListRecentMetrics',
+            type: 'accounts',
+            resource: '1234567890',
+            expected: {
+                accountId: '1234567890',
+            },
         },
     ];
 
     tests.forEach(test => {
-        const { start, end } = test;
-        it(`should handle a request range of ${end - start}ms`, done => {
-            const params = {
-                timeRange: [start, end],
-                resource: {
-                    type: 'buckets',
-                    buckets: ['my-bucket'],
-                },
+        const {
+            timeRange, type, resource, expected, action,
+        } = test;
+        const msg = timeRange
+            ? `should handle a request range of ${timeRange[1] - timeRange[0]}ms`
+            : 'should handle a ListRecentMetrics request';
+        it(msg, done => {
+            const headers = {
+                method: 'POST',
+                path: `/${type}?Action=${action}`,
             };
-            makeUtapiClientRequest(params, (err, response) => {
+            const body = {
+                timeRange,
+                [type]: [resource],
+            };
+            makeUtapiGenericClientRequest(headers, body, (err, response) => {
                 if (err) {
                     return done(err);
                 }
@@ -53,8 +119,14 @@ describe('Request ranges', function test() {
                 if (data.code) {
                     return done(new Error(data.message));
                 }
-                const { timeRange } = data[0];
-                assert.deepStrictEqual(timeRange, [start, end]);
+
+                if (timeRange) {
+                    assert.deepStrictEqual(timeRange, data[0].timeRange);
+                }
+
+                Object.entries(expected).forEach(([k, v]) => {
+                    assert.strictEqual(data[0][k], v);
+                });
                 return done();
             });
         });

--- a/tests/utils/mock/Vault.js
+++ b/tests/utils/mock/Vault.js
@@ -14,7 +14,7 @@ class Vault {
         res.writeHead(200);
         const { query } = url.parse(req.url, true);
         if (query.Action === 'AccountsCanonicalIds') {
-            const body = JSON.stringify([{ canonicalId: CANONICAL_ID }]);
+            const body = JSON.stringify([{ canonicalId: CANONICAL_ID, accountId: query.accountIds }]);
             res.write(body);
         }
         return res.end();


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1068.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-3692_fix_accountid_support_in_list_metrics_js`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-3692_fix_accountid_support_in_list_metrics_js
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-3692_fix_accountid_support_in_list_metrics_js
```

Please always comment pull request #1068 instead of this one.