### PR TITLE
bf(S3C-4550): Do not take previous reindex diffs into account when calculating its own

### DIFF
--- a/libV2/server/API/metrics/getStorage.js
+++ b/libV2/server/API/metrics/getStorage.js
@@ -40,7 +40,7 @@ async function getStorage(ctx, params) {
                 macro: 'utapi/getMetricsAt',
             };
             return warp10.exec(options);
-        });
+        }, error => ctx.logger.error('error while fetching metrics', { error }));
 
         if (res.result.length === 0) {
             ctx.logger.error('unable to retrieve metrics', { level, resource });

--- a/libV2/tasks/Reindex.js
+++ b/libV2/tasks/Reindex.js
@@ -69,6 +69,8 @@ class ReindexTask extends BaseTask {
                     labels: {
                         [level]: resource,
                     },
+                    // eslint-disable-next-line camelcase
+                    no_reindex: true,
                 },
                 macro: 'utapi/getMetricsAt',
             };

--- a/libV2/utils/func.js
+++ b/libV2/utils/func.js
@@ -42,19 +42,21 @@ function comprehend(data, func) {
  * @returns {*} -
  */
 async function iterIfError(items, func, onError) {
+    let error;
     // eslint-disable-next-line no-restricted-syntax
     for (const item of items) {
         try {
             // eslint-disable-next-line no-await-in-loop
             const resp = await func(item);
             return resp;
-        } catch (error) {
+        } catch (_error) {
             if (onError) {
-                onError(error);
+                onError(_error);
             }
+            error = _error;
         }
     }
-    throw new Error('unable to complete request');
+    throw error || new Error('unable to complete request');
 }
 
 module.exports = {

--- a/warpscript/utapi/getMetricsAt.mc2
+++ b/warpscript/utapi/getMetricsAt.mc2
@@ -32,8 +32,8 @@
 
     $operation_info 'end' GET TOLONG 'endTimestamp' STORE
     $operation_info 'labels' GET 'labels' STORE
-
     $operation_info 'node' GET 'nodeID' STORE
+    $operation_info 'no_reindex' GET true == 'no_reindex' STORE
 
     'utapi.event' 'event_class' STORE
     'utapi.checkpoint' 'checkpoint_class' STORE
@@ -288,23 +288,27 @@
     %> FOREACH
 
     'load_reindex' SECTION
-    // Only load the latest reindex for the current node
-    $labels UNMAP 'node' $nodeID } 'filterLabels' STORE
-    {
-      'token' $read_token
-      'class' $reindex_class
-      'labels' $filterLabels
-      'end' $endTimestamp
-      'count' 1
-    } FETCH
-    <% // Handle multiple GTS
-      VALUES
-      <% // For each reindex correction
-        @utapi/decodeRecord
-        // DUP 'Loaded reindex correction ' SWAP ->JSON + LOGMSG
-        $results @util/sumRecord 'results' STORE
+    <% $no_reindex NOT %>
+    <%
+      // Only load the latest reindex for the current node
+      $labels UNMAP 'node' $nodeID } 'filterLabels' STORE
+      {
+        'token' $read_token
+        'class' $reindex_class
+        'labels' $filterLabels
+        'end' $endTimestamp
+        'count' 1
+      } FETCH
+      // DUP 'Loaded reindex records ' SWAP ->JSON + LOGMSG
+      <% // Handle multiple GTS
+        VALUES
+        <% // For each reindex correction
+          @utapi/decodeRecord
+          // DUP 'Loaded reindex correction ' SWAP ->JSON + LOGMSG
+          $results @util/sumRecord 'results' STORE
+        %> FOREACH
       %> FOREACH
-    %> FOREACH
+    %> IFT
 
     $results // Leave results on the stack
 


### PR DESCRIPTION
As only the latest reindex diff is taken into account by `getMetricsAt` the diffs calculated can begin "flapping" as it over/under corrects. See ticket for a detailed explanation.