### PR TITLE
(draft) exporters for default nodejs and redis metrics

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,45 @@
+version: '3.8'
+
+x-models:
+  warp10: &warp10
+    build:
+      context: .
+      dockerfile: ./images/warp10/Dockerfile
+    volumes: [ $PWD/warpscript:/usr/local/share/warpscript ]
+
+  warp10_env: &warp10_env
+    ENABLE_WARPSTUDIO: 'true'
+    warpscript.repository.refresh: 1000
+    warpscript.maxops: 1000000000
+    warpscript.maxops.hard: 1000000000
+    warpscript.maxfetch: 1000000000
+    warpscript.maxfetch.hard: 1000000000
+    warpscript.extension.debug: io.warp10.script.ext.debug.DebugWarpScriptExtension
+    warpscript.maxrecursion: 1000
+    warpscript.repository.directory: /usr/local/share/warpscript
+    warpscript.extension.logEvent: io.warp10.script.ext.logging.LoggingWarpScriptExtension
+
+services:
+  redis:
+    image: redis
+    ports:
+      - 6379:6379
+  
+  redis-extractor:
+    image: oliver006/redis_exporter:alpine
+    ports: 
+      - 9121:9121
+    entrypoint: /redis_exporter --redis.addr=redis://redis:6379
+
+  warp10:
+    << : *warp10
+    environment:
+      << : *warp10_env
+    
+    ports:
+      - "4802:4802"
+      - "8081:8081"
+
+    volumes:
+      - /tmp/warp10:/data
+      - '${PWD}/warpscript:/usr/local/share/warpscript'

--- a/libV2/server/API/internal/prometheusMetrics.js
+++ b/libV2/server/API/internal/prometheusMetrics.js
@@ -1,0 +1,15 @@
+const { collectDefaultMetrics, register } = require('prom-client');
+
+collectDefaultMetrics({
+    timeout: 10000,
+    gcDurationBuckets: [0.001, 0.01, 0.1, 1, 2, 5],
+    prefix: 'Utapi_v2_',
+});
+
+async function prometheusMetrics(ctx) {
+    // eslint-disable-next-line no-param-reassign
+    ctx.results.statusCode = 200;
+    ctx.results.body = await register.metrics();
+}
+
+module.exports = prometheusMetrics;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -101,6 +101,12 @@ components:
                 type: string
               level:
                 type: string
+    utapi-get-prometheus-metrics:
+      description: metrics to be ingested by prometheus 
+      content:
+        text/plain:
+          schema:
+            type: string
   parameters:
     level:
       in: path
@@ -133,6 +139,16 @@ paths:
           $ref: '#/components/responses/json-error'
         200:
           description: Service is healthy
+  /_/metrics:
+    get:
+      x-router-controller: internal
+      x-iplimit: true
+      operationId: prometheusMetrics
+      responses:
+        default:
+          $ref: '#/components/responses/json-error'
+        200:
+          $ref: '#/components/responses/utapi-get-prometheus-metrics'
   /v2/ingest:
     post:
       x-router-controller: metrics

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "needle": "^2.5.0",
     "node-schedule": "^1.3.2",
     "oas-tools": "^2.1.8",
+    "prom-client": "^13.1.0",
     "uuid": "^3.3.2",
     "vaultclient": "scality/vaultclient#ff9e92f",
     "werelogs": "scality/werelogs#0a4c576"


### PR DESCRIPTION
This provides metrics for NodeJs and Redis which Prometheus can scrape. To scrape Redis, an [exporter](https://github.com/oliver006/redis_exporter) is used as a service which also provides metrics about itself (scrape durations, memory usage, etc). Additionally, warp10 metrics and custom metrics for Utapi server will be added soon. 

Currently, the available metrics are:
    NodeJs:                 https://github.com/siimon/prom-client/tree/master/lib/metrics
    Redis:                    https://redis.io/commands/info
    Redis-Exporter:    https://github.com/oliver006/redis_exporter/blob/master/exporter/exporter.go (starting at line 322)
    
The functionality in this draft only targets Utapi V2.
    
    