### PR TITLE
prometheus exporters for nodejs, redis, warp10 metrics

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,47 @@
+version: '3.8'
+
+x-models:
+  warp10: &warp10
+    build:
+      context: .
+      dockerfile: ./images/warp10/Dockerfile
+    volumes: [ $PWD/warpscript:/usr/local/share/warpscript ]
+
+  warp10_env: &warp10_env
+    ENABLE_WARPSTUDIO: 'true'
+    ENABLE_SENSISION: 'true'
+    warpscript.repository.refresh: 1000
+    warpscript.maxops: 1000000000
+    warpscript.maxops.hard: 1000000000
+    warpscript.maxfetch: 1000000000
+    warpscript.maxfetch.hard: 1000000000
+    warpscript.extension.debug: io.warp10.script.ext.debug.DebugWarpScriptExtension
+    warpscript.maxrecursion: 1000
+    warpscript.repository.directory: /usr/local/share/warpscript
+    warpscript.extension.logEvent: io.warp10.script.ext.logging.LoggingWarpScriptExtension
+  
+  redis: &redis
+      build:
+        context: .
+        dockerfile: ./images/redis/Dockerfile
+
+services:
+  redis:
+    << : *redis
+    ports:
+      - 6379:6379
+      - 9121:9121
+
+  warp10:
+    << : *warp10
+    environment:
+      << : *warp10_env
+
+    ports:
+      - 4802:4802
+      - 8081:8081
+      - 9718:9718
+
+    volumes:
+      - /tmp/warp10:/data
+      - '${PWD}/warpscript:/usr/local/share/warpscript'

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -22,6 +22,9 @@ models:
         warp10:
           context: '.'
           dockerfile: 'images/warp10/Dockerfile'
+        redis:
+          context: '.'
+          dockerfile: 'images/redis/Dockerfile'
         vault: eve/workers/mocks/vault
   - Upload: &upload_artifacts
       source: /artifacts

--- a/eve/workers/pod.yml
+++ b/eve/workers/pod.yml
@@ -15,7 +15,7 @@ spec:
         cpu: 500m
         memory: 3Gi
       limits:
-        cpu: "2"
+        cpu: 1500m
         memory: 3Gi
     volumeMounts:
     - mountPath: /var/run/docker.sock
@@ -36,11 +36,28 @@ spec:
         value: '10000000'
     resources:
       requests:
-        cpu: 500m
+        cpu: 300m
         memory: 1Gi
       limits:
-        cpu: 1750m
+        cpu: 1000m
         memory: 3Gi
+    volumeMounts:
+    - name: artifacts
+      readOnly: false
+      mountPath: /artifacts
+  - name: redis
+    image: "{{ images.redis }}"
+    command:
+      - sh
+      - -ce
+      - /init | tee -a /artifacts/redis.log
+    resources:
+      requests:
+        cpu: 200m
+        memory: 1Gi
+      limits:
+        cpu: 200m
+        memory: 1Gi
     volumeMounts:
     - name: artifacts
       readOnly: false

--- a/images/redis/Dockerfile
+++ b/images/redis/Dockerfile
@@ -1,0 +1,17 @@
+FROM redis:alpine
+
+ENV S6_VERSION 2.0.0.1
+ENV EXPORTER_VERSION 1.24.0
+ENV S6_BEHAVIOUR_IF_STAGE2_FAILS 2
+
+RUN wget https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-amd64.tar.gz -O /tmp/s6-overlay-amd64.tar.gz \
+    && tar xzf /tmp/s6-overlay-amd64.tar.gz -C / \
+    && rm -rf /tmp/s6-overlay-amd64.tar.gz 
+
+RUN wget https://github.com/oliver006/redis_exporter/releases/download/v${EXPORTER_VERSION}/redis_exporter-v${EXPORTER_VERSION}.linux-amd64.tar.gz -O redis_exporter.tar.gz \
+    && tar xzf redis_exporter.tar.gz -C / \
+    && cd .. \
+    && mv /redis_exporter-v${EXPORTER_VERSION}.linux-amd64/redis_exporter /usr/local/bin/redis_exporter
+
+ADD ./images/redis/s6 /etc
+CMD /init

--- a/images/redis/s6/services.d/exporter/run
+++ b/images/redis/s6/services.d/exporter/run
@@ -1,0 +1,4 @@
+#!/usr/bin/with-contenv sh
+echo "starting redis exporter"
+exec redis_exporter
+

--- a/images/redis/s6/services.d/redis/run
+++ b/images/redis/s6/services.d/redis/run
@@ -1,0 +1,4 @@
+#!/usr/bin/with-contenv sh
+echo "starting redis"
+exec redis-server
+

--- a/images/warp10/Dockerfile
+++ b/images/warp10/Dockerfile
@@ -1,3 +1,18 @@
+FROM golang:1.14-alpine as builder
+
+ENV WARP10_EXPORTER_VERSION 2.7.5
+
+RUN apk add zip unzip build-base \
+    && wget -q -O exporter.zip https://github.com/centreon/warp10-sensision-exporter/archive/refs/heads/master.zip \
+    && unzip exporter.zip \
+    && cd warp10-sensision-exporter-master \
+    && go mod download \
+    && cd tools \
+    && go run generate_sensision_metrics.go ${WARP10_EXPORTER_VERSION} \
+    && cp sensision.go ../collector/ \
+    && cd .. \
+    && go build -a -o /usr/local/go/warp10_sensision_exporter
+
 FROM warp10io/warp10:2.7.5
 
 ENV S6_VERSION 2.0.0.1
@@ -5,6 +20,7 @@ ENV S6_BEHAVIOUR_IF_STAGE2_FAILS 2
 
 ENV WARP10_CONF_TEMPLATES ${WARP10_HOME}/conf.templates/standalone
 ENV SENSISION_DATA_DIR /data/sensision
+ENV SENSISION_PORT 8082
 
 # Modify Warp 10 default config
 ENV standalone.host 0.0.0.0
@@ -23,7 +39,12 @@ RUN wget https://github.com/just-containers/s6-overlay/releases/download/v${S6_V
 # Install protobuf extestion
 ADD ./images/warp10/warp10-ext-protobuf-1.2.2-uberjar.jar /opt/warp10/lib/
 
+# Install Sensision exporter
+COPY --from=builder /usr/local/go/warp10_sensision_exporter /usr/local/bin/warp10_sensision_exporter
+
 ADD ./images/warp10/s6 /etc
 ADD ./warpscript /usr/local/share/warpscript
 ADD ./images/warp10/static.tokens /
+
 CMD /init
+

--- a/images/warp10/s6/services.d/sensision-exporter/run
+++ b/images/warp10/s6/services.d/sensision-exporter/run
@@ -1,0 +1,4 @@
+#!/usr/bin/with-contenv sh
+
+echo 'Starting sensision exporter'
+exec warp10_sensision_exporter --warp10.url=http://localhost:${SENSISION_PORT}/metrics

--- a/images/warp10/s6/services.d/sensision/run
+++ b/images/warp10/s6/services.d/sensision/run
@@ -3,7 +3,7 @@
 JAVA="/usr/bin/java"
 JAVA_OPTS=""
 
-VERSION=1.0.21
+VERSION=1.0.23
 SENSISION_CONFIG=${SENSISION_DATA_DIR}/conf/sensision.conf
 SENSISION_JAR=${SENSISION_HOME}/bin/sensision-${VERSION}.jar
 SENSISION_CP=${SENSISION_HOME}/etc:${SENSISION_JAR}
@@ -14,7 +14,7 @@ if [ -z "$SENSISION_HEAP" ]; then
     SENSISION_HEAP=64m
 fi
 
-SENSISION_CMD="${JAVA} ${JAVA_OPTS} -Xmx${SENSISION_HEAP} -Dsensision.server.port=0 ${SENSISION_OPTS} -Dsensision.config=${SENSISION_CONFIG} -cp ${SENSISION_CP} ${SENSISION_CLASS}"
+SENSISION_CMD="${JAVA} ${JAVA_OPTS} -Xmx${SENSISION_HEAP} -Dsensision.server.port=${SENSISION_PORT} ${SENSISION_OPTS} -Dsensision.config=${SENSISION_CONFIG} -cp ${SENSISION_CP} ${SENSISION_CLASS}"
 
 if [ -n "$ENABLE_SENSISION" ]; then
     echo "Starting Sensision with $SENSISION_CMD ..."

--- a/images/warp10/s6/services.d/warp10/run
+++ b/images/warp10/s6/services.d/warp10/run
@@ -28,7 +28,7 @@ if [ -n "$ENABLE_SENSISION" ]; then
     if [ -n "$SENSISION_LABELS" ]; then
         _SENSISION_LABELS="-Dsensision.default.labels=$SENSISION_LABELS"
     fi
-    SENSISION_OPTS="-Dsensision.server.port=0 ${_SENSISION_LABELS} -Dsensision.events.dir=/var/run/sensision/metrics -Dfile.encoding=UTF-8"
+    SENSISION_OPTS="${_SENSISION_LABELS} -Dsensision.events.dir=/var/run/sensision/metrics -Dfile.encoding=UTF-8"
 fi
 
 WARP10_CMD="${JAVA} -Dlog4j.configuration=file:${LOG4J_CONF} ${JAVA_OPTS} ${SENSISION_OPTS} -cp ${WARP10_CP} ${WARP10_CLASS} ${CONFIG_FILES}"

--- a/libV2/server/API/internal/prometheusMetrics.js
+++ b/libV2/server/API/internal/prometheusMetrics.js
@@ -1,0 +1,14 @@
+const { collectDefaultMetrics, register } = require('prom-client');
+
+collectDefaultMetrics({
+    timeout: 10000,
+    gcDurationBuckets: [0.001, 0.01, 0.1, 1, 2, 5],
+});
+
+async function prometheusMetrics(ctx) {
+    // eslint-disable-next-line no-param-reassign
+    ctx.results.statusCode = 200;
+    ctx.results.body = await register.metrics();
+}
+
+module.exports = prometheusMetrics;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -101,6 +101,12 @@ components:
                 type: string
               level:
                 type: string
+    utapi-get-prometheus-metrics:
+      description: metrics to be ingested by prometheus 
+      content:
+        text/plain:
+          schema:
+            type: string
   parameters:
     level:
       in: path
@@ -133,6 +139,16 @@ paths:
           $ref: '#/components/responses/json-error'
         200:
           description: Service is healthy
+  /_/metrics:
+    get:
+      x-router-controller: internal
+      x-iplimit: true
+      operationId: prometheusMetrics
+      responses:
+        default:
+          $ref: '#/components/responses/json-error'
+        200:
+          $ref: '#/components/responses/utapi-get-prometheus-metrics'
   /v2/ingest:
     post:
       x-router-controller: metrics

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "needle": "^2.5.0",
     "node-schedule": "^1.3.2",
     "oas-tools": "^2.1.8",
+    "prom-client": "^13.1.0",
     "uuid": "^3.3.2",
     "vaultclient": "scality/vaultclient#ff9e92f",
     "werelogs": "scality/werelogs#0a4c576"
@@ -50,6 +51,12 @@
     "protobufjs": "^6.10.1",
     "sinon": "^9.0.2"
   },
+  "resolutions": {
+    "**/@yarnpkg/fslib": "2.4.0",
+    "**/@yarnpkg/libzip" : "2.2.1",
+    "**/@yarnpkg/json-proxy": "2.1.0",
+    "**/@yarnpkg/parsers": "2.3.0"
+},
   "scripts": {
     "ft_test": "mocha --recursive tests/functional",
     "ft_test:client": "mocha --recursive tests/functional/client",

--- a/tests/functional/v2/server/testPrometheusMetrics.js
+++ b/tests/functional/v2/server/testPrometheusMetrics.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+const needle = require('needle');
+
+const testMetrics = async pair => {
+    const [name, url] = pair;
+    it(`should return metrics for ${name} from url ${url}`, async () => {
+        const res = await needle('get', url);
+        const lines = res.body.split('\n');
+        const first = lines[0];
+
+        assert.strictEqual(res.statusCode, 200);
+        assert(first.startsWith('# HELP'));
+    });
+};
+
+describe('Test Prometheus Metrics', () => {
+    const nameUrlPairs = [
+        ['utapi nodejs service exporter', 'http://localhost:8100/_/metrics'],
+        ['sensision exporter', 'http://localhost:9718/metrics'],
+        ['redis exporter', 'http://localhost:9121/metrics'],
+    ];
+    nameUrlPairs.forEach(pair => testMetrics(pair));
+});

--- a/tests/unit/v2/API/internal/testPrometheusMetrics.js
+++ b/tests/unit/v2/API/internal/testPrometheusMetrics.js
@@ -1,0 +1,35 @@
+const assert = require('assert');
+const { RequestContext } = require('../../../../../libV2/models');
+const { templateRequest } = require('../../../../utils/v2Data');
+const prometheusMetrics = require('../../../../../libV2/server/API/internal/prometheusMetrics');
+
+describe('Test prometheusMetrics', () => {
+    const overrides = {
+        swagger: {
+            operation: {
+                'x-router-controller': 'internal',
+                'operationId': 'prometheusMetrics',
+            },
+            params: {},
+        },
+    };
+    const ctx = new RequestContext(templateRequest(overrides));
+
+    before(async () => {
+        await prometheusMetrics(ctx);
+    });
+
+    it('should set statusCode to 200', () => {
+        assert.strictEqual(ctx.results.statusCode, 200);
+    });
+
+    it('should have a response body', () => {
+        assert.strictEqual(typeof ctx.results.body, 'string');
+    });
+
+    it('should contain metrics', () => {
+        const lines = ctx.results.body.split('\n');
+        const first = lines[0];
+        assert(first.startsWith('# HELP'));
+    });
+});

--- a/tests/unit/v2/server/testController.js
+++ b/tests/unit/v2/server/testController.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 
 const APIController = require('../../../../libV2/server/controller');
 const healthcheck = require('../../../../libV2/server/API/internal/healthcheck');
+const prometheusMetrics = require('../../../../libV2/server/API/internal/prometheusMetrics');
 
 const { ResponseContainer } = require('../../../../libV2/models');
 const { ExpressResponseStub, templateRequest } = require('../../../utils/v2Data');
@@ -41,6 +42,7 @@ describe('Test APIController', () => {
         const handlers = APIController._collectHandlers('internal');
         assert.deepStrictEqual(handlers, {
             healthcheck,
+            prometheusMetrics,
         });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4633,6 +4633,13 @@ prom-client@10.2.3:
   dependencies:
     tdigest "^0.1.1"
 
+prom-client@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-13.1.0.tgz#1185caffd8691e28d32e373972e662964e3dba45"
+  integrity sha512-jT9VccZCWrJWXdyEtQddCDszYsiuWj5T0ekrPszi/WEegj3IZy6Mm09iOOVM86A4IKMWq8hZkT2dD9MaSe+sng==
+  dependencies:
+    tdigest "^0.1.1"
+
 promise-fs@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/promise-fs/-/promise-fs-2.1.1.tgz#0b725a592c165ff16157d1f13640ba390637e557"


### PR DESCRIPTION
This provides metrics for NodeJs and Redis which Prometheus can scrape. To scrape Redis, an exporter is used as a service which also provides metrics about itself (scrape durations, memory usage, etc). Additionally, warp10 metrics and custom metrics for Utapi server will be added soon.

Currently, the available metrics are:
NodeJs: https://github.com/siimon/prom-client/tree/master/lib/metrics
Redis: https://redis.io/commands/info
Redis-Exporter: https://github.com/oliver006/redis_exporter/blob/master/exporter/exporter.go (starting at line 322)

The functionality in this draft only targets Utapi V2.