### PR TITLE
INTEGRATION [PR#1107 > development/7.10] UTAPI-5 update werelogs to tagged version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "node-schedule": "1.2.0",
     "uuid": "^3.3.2",
     "vaultclient": "scality/vaultclient#cc9ba34",
-    "werelogs": "scality/werelogs#4e0d97c"
+    "werelogs": "scality/werelogs#8.1.0"
   },
   "devDependencies": {
     "aws4": "^1.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2529,6 +2529,12 @@ werelogs@scality/werelogs#4e0d97c:
   dependencies:
     safe-json-stringify "1.0.3"
 
+werelogs@scality/werelogs#8.1.0:
+  version "8.1.0"
+  resolved "https://codeload.github.com/scality/werelogs/tar.gz/e8f828725642c54c511cdbe580b18f43d3589313"
+  dependencies:
+    safe-json-stringify "1.0.3"
+
 word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1107.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/feature/UTAPI-5-bump-werelogs`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/feature/UTAPI-5-bump-werelogs
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/feature/UTAPI-5-bump-werelogs
```

Please always comment pull request #1107 instead of this one.