### PR TITLE
INTEGRATION [PR#1119 > development/8.1] disconnect stuck connection on failover before retry

### DIFF
--- a/libV2/redis.js
+++ b/libV2/redis.js
@@ -68,6 +68,7 @@ class RedisClient extends EventEmitter {
             this._redis.off('connect', this._onConnect);
             this._redis.off('ready', this._onReady);
             this._redis.off('error', this._onError);
+            this._redis.disconnect();
         }
         this._isConnected = false;
         this._isReady = false;


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1119.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-4784_redis-connection-buildup-stabilization`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-4784_redis-connection-buildup-stabilization
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-4784_redis-connection-buildup-stabilization
```

Please always comment pull request #1119 instead of this one.