### PR TITLE
impr(UTAPI-32): Change service user arnPrefix to full arn

### DIFF
--- a/libV2/config/defaults.json
+++ b/libV2/config/defaults.json
@@ -46,7 +46,7 @@
         "expirationEnabled": false
     },
     "serviceUser": {
-        "arnPrefix": "arn:aws:iam::000000000000:",
+        "arn": "arn:aws:iam::000000000000:user/scality-internal/service-utapi-user",
         "enabled": false
     }
 }

--- a/libV2/config/index.js
+++ b/libV2/config/index.js
@@ -341,7 +341,7 @@ class Config {
         parsedConfig.bucketd = _loadFromEnv('BUCKETD_BOOTSTRAP', config.bucketd, _typeCasts.serverList);
 
         parsedConfig.serviceUser = {
-            arnPrefix: _loadFromEnv('SERVICE_USER_ARN_PREFIX', config.serviceUser.arnPrefix),
+            arn: _loadFromEnv('SERVICE_USER_ARN', config.serviceUser.arn),
             enabled: _loadFromEnv('SERVICE_USER_ENABLED', config.serviceUser.enabled, _typeCasts.bool),
         };
 

--- a/libV2/config/schema.js
+++ b/libV2/config/schema.js
@@ -85,6 +85,10 @@ const schema = Joi.object({
         expirationEnabled: Joi.boolean(),
         hardLimit: Joi.string(),
     }),
+    serviceUser: Joi.object({
+        arn: Joi.string(),
+        enabled: Joi.boolean(),
+    }),
 });
 
 module.exports = schema;

--- a/libV2/vault/index.js
+++ b/libV2/vault/index.js
@@ -155,7 +155,7 @@ async function translateAndAuthorize(request, action, level, resources) {
         return [false, []];
     }
 
-    if (config.serviceUser.enabled && authInfo.getArn().startsWith(config.serviceUser.arnPrefix)) {
+    if (config.serviceUser.enabled && authInfo.getArn() === config.serviceUser.arn) {
         return authorizeServiceUser(authInfo, level, authorizedResources, request.logger);
     }
 

--- a/tests/functional/v2/server/testListMetrics.js
+++ b/tests/functional/v2/server/testListMetrics.js
@@ -110,7 +110,7 @@ describe('Test listMetric', function () {
         otherAccount = await vaultclient.createAccountAndKeys(uuid.v4());
         otherUser = await vaultclient.createUser(otherAccount, uuid.v4());
         const serviceAccount = await vaultclient.createInternalServiceAccountAndKeys();
-        serviceUser = await vaultclient.createUserAndKeys(serviceAccount, 'utapi-service-user');
+        serviceUser = await vaultclient.createUserAndKeys(serviceAccount, 'service-utapi-user');
 
         await Promise.all([
             vaultclient.createAndAttachUtapiPolicy(account, user, 'buckets', '*'),

--- a/tests/utils/vaultclient.js
+++ b/tests/utils/vaultclient.js
@@ -11,7 +11,7 @@ const adminCredentials = {
 
 
 const internalServiceAccountId = '000000000000';
-const internalServiceAccountName = 'scality-internal-services';
+const internalServiceAccountName = 'scality-internal';
 const internalServiceAccountEmail = 'scality@internal';
 
 class VaultClient {


### PR DESCRIPTION
closes a small security hole that would allow a different internal user with a name beginning with the utapi service user to bypass authorization.