### PR TITLE
INTEGRATION [PR#1152 > development/8.1] impr(UTAPI-36): Bump vault cpu request and limit

### DIFF
--- a/eve/workers/pod.yml
+++ b/eve/workers/pod.yml
@@ -119,10 +119,10 @@ spec:
         value: LEVELDB
     resources:
       requests:
-        cpu: 150m
+        cpu: 500m
         memory: 1Gi
       limits:
-        cpu: 150m
+        cpu: 500m
         memory: 1Gi
     volumeMounts:
     - name: artifacts


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1152.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/improvement/UTAPI-36/bump_vault_cpu_req`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/improvement/UTAPI-36/bump_vault_cpu_req
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/improvement/UTAPI-36/bump_vault_cpu_req
```

Please always comment pull request #1152 instead of this one.