### PR TITLE
bf(UTAPI-42): Update upstream warp 10 image repo

### DIFF
--- a/images/warp10/Dockerfile
+++ b/images/warp10/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add zip unzip build-base \
     && cd .. \
     && go build -a -o /usr/local/go/warp10_sensision_exporter
 
-FROM warp10io/warp10:master
+FROM registry.scality.com/utapi/warp10:2.8.1-95-g73e7de80
 
 # Override baked in version
 # Remove when updating to a numbered release


### PR DESCRIPTION
Update to our registry as the image tag has changed and fails to build