### PR TITLE
INTEGRATION [PR#1180 > development/8.1] bugfix: support redis retry params in v2

### DIFF
--- a/eve/workers/unit_and_feature_tests/Dockerfile
+++ b/eve/workers/unit_and_feature_tests/Dockerfile
@@ -49,7 +49,7 @@ RUN yarn cache clean \
 #
 
 ARG BUILDBOT_VERSION=2.7.0
-RUN pip3 install buildbot-worker==$BUILDBOT_VERSION requests redis
+RUN pip3 install buildbot-worker==$BUILDBOT_VERSION requests redis==3.5.3
 ADD eve/workers/unit_and_feature_tests/supervisor/buildbot_worker.conf /etc/supervisor/conf.d/
 ADD eve/workers/unit_and_feature_tests/redis/sentinel.conf /etc/sentinel.conf
 

--- a/libV2/config/index.js
+++ b/libV2/config/index.js
@@ -176,7 +176,9 @@ class Config {
     }
 
     static _parseRedisConfig(prefix, config) {
-        const redisConf = {};
+        const redisConf = {
+            retry: config.retry,
+        };
         if (config.sentinels || _definedInEnv(`${prefix}_SENTINELS`)) {
             redisConf.name = _loadFromEnv(`${prefix}_NAME`, config.name);
             redisConf.sentinels = _loadFromEnv(

--- a/libV2/config/schema.js
+++ b/libV2/config/schema.js
@@ -1,9 +1,22 @@
 const Joi = require('@hapi/joi');
 
+const backoffSchema = Joi.object({
+    min: Joi.number(),
+    max: Joi.number(),
+    deadline: Joi.number(),
+    jitter: Joi.number(),
+    factor: Joi.number(),
+});
+
+const redisRetrySchema = Joi.object({
+    connectBackoff: backoffSchema,
+});
+
 const redisServerSchema = Joi.object({
     host: Joi.string(),
     port: Joi.number(),
     password: Joi.string().allow(''),
+    retry: redisRetrySchema,
 });
 
 const redisSentinelSchema = Joi.object({
@@ -14,6 +27,7 @@ const redisSentinelSchema = Joi.object({
     })),
     password: Joi.string().default('').allow(''),
     sentinelPassword: Joi.string().default('').allow(''),
+    retry: redisRetrySchema,
 });
 
 const warp10SingleHost = Joi.object({


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1180.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/UTAPI-46-redisv2-backoff`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/UTAPI-46-redisv2-backoff
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/UTAPI-46-redisv2-backoff
```

Please always comment pull request #1180 instead of this one.