### PR TITLE
INTEGRATION [PR#1190 > development/8.1] impr(S3C-4767): skip objects without a content-length during reindex

### DIFF
--- a/libV2/tasks/Reindex.js
+++ b/libV2/tasks/Reindex.js
@@ -41,6 +41,13 @@ class ReindexTask extends BaseTask {
                 // eslint-disable-next-line no-continue
                 continue;
             }
+
+            if (!Number.isInteger(obj.value['content-length'])) {
+                logger.debug('object missing content-length, not including in count');
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+
             count += 1;
             size += obj.value['content-length'];
 


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1190.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/UTAPI-53/handle_missing_content_length`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/UTAPI-53/handle_missing_content_length
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/UTAPI-53/handle_missing_content_length
```

Please always comment pull request #1190 instead of this one.