### PR TITLE
bf(UTAPI-53): skip objects without a content-length during reindex

### DIFF
--- a/libV2/tasks/Reindex.js
+++ b/libV2/tasks/Reindex.js
@@ -51,6 +51,13 @@ class ReindexTask extends BaseTask {
                 // eslint-disable-next-line no-continue
                 continue;
             }
+
+            if (!Number.isInteger(obj.value['content-length'])) {
+                logger.debug('object missing content-length, not including in count');
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+
             count += 1;
             size += obj.value['content-length'];
 


### PR DESCRIPTION
(cherry picked from commit 6c1a2c87fb3f425dbf05623ed1e5effc68ea216b)