### PR TITLE
INTEGRATION [PR#1200 > development/8.1] ft(UTAPI-56): Expose warp 10 request timeouts in config

### DIFF
--- a/libV2/config/defaults.json
+++ b/libV2/config/defaults.json
@@ -16,7 +16,9 @@
     "warp10": {
         "host": "127.0.0.1",
         "port": 4802,
-        "nodeId": "single_node"
+        "nodeId": "single_node",
+        "requestTimeout": 60000,
+        "connectTimeout": 60000
     },
     "healthChecks": {
         "allowFrom": ["127.0.0.1/8", "::1"]

--- a/libV2/config/index.js
+++ b/libV2/config/index.js
@@ -289,6 +289,8 @@ class Config {
         const warp10Conf = {
             readToken: _loadFromEnv('WARP10_READ_TOKEN', config.warp10.readToken),
             writeToken: _loadFromEnv('WARP10_WRITE_TOKEN', config.warp10.writeToken),
+            requestTimeout: _loadFromEnv('WARP10_REQUEST_TIMEOUT', config.warp10.requestTimeout, _typeCasts.int),
+            connectTimeout: _loadFromEnv('WARP10_CONNECT_TIMEOUT', config.warp10.connectTimeout, _typeCasts.int),
         };
 
         if (Array.isArray(config.warp10.hosts) || _definedInEnv('WARP10_HOSTS')) {

--- a/libV2/warp10.js
+++ b/libV2/warp10.js
@@ -123,6 +123,8 @@ const clients = _config.warp10.hosts.map(
     val => new Warp10Client({
         readToken: _config.warp10.readToken,
         writeToken: _config.warp10.writeToken,
+        connectTimeout: _config.warp10.connectTimeout,
+        requestTimeout: _config.warp10.requestTimeout,
         ...val,
     }),
 );


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1200.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/feature/UTAPI-56/expose_warp10_request_timeouts_in_config`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/feature/UTAPI-56/expose_warp10_request_timeouts_in_config
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/feature/UTAPI-56/expose_warp10_request_timeouts_in_config
```

Please always comment pull request #1200 instead of this one.