### PR TITLE
INTEGRATION [PR#1237 > development/8.1] bf(UTAPI-72): Fix CacheClient.pushMetric() to `await` this._cacheBackend.addToShard()

### DIFF
--- a/libV2/cache/client.js
+++ b/libV2/cache/client.js
@@ -23,7 +23,7 @@ class CacheClient {
 
     async pushMetric(metric) {
         const shard = shardFromTimestamp(metric.timestamp);
-        if (!this._cacheBackend.addToShard(shard, metric)) {
+        if (!(await this._cacheBackend.addToShard(shard, metric))) {
             return false;
         }
         await this._counterBackend.updateCounters(metric);


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1237.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/UTAPI-72/add_missing_await_to_pushMetric`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/UTAPI-72/add_missing_await_to_pushMetric
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/UTAPI-72/add_missing_await_to_pushMetric
```

Please always comment pull request #1237 instead of this one.