### PR TITLE
HOTFIX 7.10.3 bf(UTAPI-72): Fix CacheClient.pushMetric() to `await` this._cacheBackend.addToShard()

### DIFF
--- a/libV2/cache/client.js
+++ b/libV2/cache/client.js
@@ -23,7 +23,7 @@ class CacheClient {
 
     async pushMetric(metric) {
         const shard = shardFromTimestamp(metric.timestamp);
-        if (!this._cacheBackend.addToShard(shard, metric)) {
+        if (!(await this._cacheBackend.addToShard(shard, metric))) {
             return false;
         }
         await this._counterBackend.updateCounters(metric);


### PR DESCRIPTION
(cherry picked from commit 43ca83cab720c85636fb4fc91df1a6488a50ef41)