### PR TITLE
INTEGRATION [PR#1241 > development/8.1] ft(UTAPI-70): Add http server metrics

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -103,7 +103,8 @@ jobs:
         test:
         - name: run unit tests
           command: yarn test
-          env: {}
+          env:
+            UTAPI_METRICS_ENABLED: 'true'
         - name: run client tests
           command: bash ./.github/scripts/run_ft_tests.bash false ft_test:client
           env: {}

--- a/libV2/server/index.js
+++ b/libV2/server/index.js
@@ -28,6 +28,7 @@ class UtapiServer extends Process {
         app.use(middleware.loggerMiddleware);
         await initializeOasTools(spec, app);
         app.use(middleware.errorMiddleware);
+        app.use(middleware.httpMetricsMiddleware);
         app.use(middleware.responseLoggerMiddleware);
         return app;
     }

--- a/libV2/server/metrics.js
+++ b/libV2/server/metrics.js
@@ -1,0 +1,20 @@
+const promClient = require('prom-client');
+
+const httpRequestsTotal = new promClient.Counter({
+    name: 'utapi_http_requests_total',
+    help: 'Total number of HTTP requests',
+    labelNames: ['action', 'code'],
+});
+
+const httpRequestDurationSeconds = new promClient.Histogram({
+    name: 'utapi_http_request_duration_seconds',
+    help: 'Duration of HTTP requests in seconds',
+    labelNames: ['action', 'code'],
+    // buckets for response time from 0.1ms to 60s
+    buckets: [0.0001, 0.005, 0.015, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 5.0, 15.0, 30.0, 60.0],
+});
+
+module.exports = {
+    httpRequestDurationSeconds,
+    httpRequestsTotal,
+};

--- a/tests/unit/v2/models/testRequestContext.js
+++ b/tests/unit/v2/models/testRequestContext.js
@@ -10,6 +10,7 @@ const templateExpected = opts => ({
     operationId: 'healthcheck',
     tag: 'internal',
     encrypted: false,
+    requestTimer: null,
     ...(opts || {}),
 });
 


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1241.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/feature/UTAPI-70/add_metrics_to_http_server`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/feature/UTAPI-70/add_metrics_to_http_server
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/feature/UTAPI-70/add_metrics_to_http_server
```

Please always comment pull request #1241 instead of this one.