### PR TITLE
INTEGRATION [PR#1249 > development/8.1] ft(UTAPI-75): Add metrics for latest checkpoint and snapshot

### DIFF
--- a/libV2/tasks/BaseTask.js
+++ b/libV2/tasks/BaseTask.js
@@ -48,6 +48,11 @@ class BaseTask extends Process {
         }
 
         if (this._enableMetrics) {
+            promClient.collectDefaultMetrics({
+                timeout: 10000,
+                gcDurationBuckets: [0.001, 0.01, 0.1, 1, 2, 5],
+            });
+
             this._metricsHandlers = {
                 ...this._registerDefaultMetricHandlers(),
                 ...this._registerMetricHandlers(),

--- a/libV2/tasks/CreateCheckpoint.js
+++ b/libV2/tasks/CreateCheckpoint.js
@@ -29,8 +29,26 @@ class CreateCheckpoint extends BaseTask {
             labelNames: ['origin', 'containerName'],
         });
 
+        const getLastCheckpoint = this._getLastCheckpoint.bind(this);
+        const lastCheckpoint = new promClient.Gauge({
+            name: 'utapi_create_checkpoint_last_checkpoint_seconds',
+            help: 'Timestamp of the last successfully created checkpoint',
+            labelNames: ['origin', 'containerName'],
+            async collect() {
+                try {
+                    const timestamp = await getLastCheckpoint();
+                    if (timestamp !== null) {
+                        this.set(timestamp);
+                    }
+                } catch (error) {
+                    logger.error('error during metric collection', { error });
+                }
+            },
+        });
+
         return {
             created,
+            lastCheckpoint,
         };
     }
 
@@ -53,6 +71,25 @@ class CreateCheckpoint extends BaseTask {
         if (metrics.created !== undefined) {
             this._metricsHandlers.created.inc(metrics.created);
         }
+    }
+
+    async _getLastCheckpoint() {
+        const resp = await this.withWarp10(async warp10 => warp10.fetch({
+            className: 'utapi.checkpoint.master',
+            labels: {
+                node: warp10.nodeId,
+            },
+            start: 'now',
+            stop: -1,
+        }));
+
+        if (resp.result && (resp.result.length === 0 || resp.result[0] === '' || resp.result[0] === '[]')) {
+            return null;
+        }
+
+        const result = JSON.parse(resp.result[0])[0];
+        const timestamp = result.v[0][0];
+        return timestamp / 1000000;// Convert timestamp from microseconds to seconds
     }
 
     async _execute(timestamp) {

--- a/libV2/tasks/CreateSnapshot.js
+++ b/libV2/tasks/CreateSnapshot.js
@@ -29,8 +29,26 @@ class CreateSnapshot extends BaseTask {
             labelNames: ['origin', 'containerName'],
         });
 
+        const getLastSnapshot = this._getLastSnapshot.bind(this);
+        const lastSnapshot = new promClient.Gauge({
+            name: 'utapi_create_snapshot_last_snapshot_seconds',
+            help: 'Timestamp of the last successfully created snapshot',
+            labelNames: ['origin', 'containerName'],
+            async collect() {
+                try {
+                    const timestamp = await getLastSnapshot();
+                    if (timestamp !== null) {
+                        this.set(timestamp);
+                    }
+                } catch (error) {
+                    logger.error('error during metric collection', { error });
+                }
+            },
+        });
+
         return {
             created,
+            lastSnapshot,
         };
     }
 
@@ -53,6 +71,25 @@ class CreateSnapshot extends BaseTask {
         if (metrics.created !== undefined) {
             this._metricsHandlers.created.inc(metrics.created);
         }
+    }
+
+    async _getLastSnapshot() {
+        const resp = await this.withWarp10(async warp10 => warp10.fetch({
+            className: 'utapi.snapshot.master',
+            labels: {
+                node: warp10.nodeId,
+            },
+            start: 'now',
+            stop: -1,
+        }));
+
+        if (resp.result && (resp.result.length === 0 || resp.result[0] === '' || resp.result[0] === '[]')) {
+            return null;
+        }
+
+        const result = JSON.parse(resp.result[0])[0];
+        const timestamp = result.v[0][0];
+        return timestamp / 1000000;// Convert timestamp from microseconds to seconds
     }
 
     async _execute(timestamp) {

--- a/warpscript/utapi/createCheckpoint.mc2
+++ b/warpscript/utapi/createCheckpoint.mc2
@@ -115,7 +115,16 @@
       %> FOREACH
      %>
     <%
-       DROP 0 STOP
+      // If no new events were found
+      // - drop the empty list
+      // - write a new master checkpoint
+      // - return 0
+      DROP
+      NEWGTS $master_checkpoint_class RENAME
+      $endTimestamp NaN NaN NaN 0 ADDVALUE
+      { 'node' $nodeId } RELABEL
+      $write_token UPDATE
+      0 STOP
     %> IFTE
 
     0 'checkpoints' STORE


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1249.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/feature/UTAPI-75/Add_metrics_for_latest_check_snapshot_timestamps`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/feature/UTAPI-75/Add_metrics_for_latest_check_snapshot_timestamps
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/feature/UTAPI-75/Add_metrics_for_latest_check_snapshot_timestamps
```

Please always comment pull request #1249 instead of this one.