### PR TITLE
INTEGRATION [PR#1251 > development/8.1] ft(UTAPI-76): Breakout disk usage for leveldb and datalog

### DIFF
--- a/libV2/tasks/DiskUsage.js
+++ b/libV2/tasks/DiskUsage.js
@@ -281,7 +281,7 @@ class MonitorDiskUsage extends BaseTask {
 
         const size = leveldbBytes + datalogBytes;
         if (this._hardLimit !== null) {
-            moduleLogger.info(`warp 10 leveldb using ${formatDiskSize(size)} of disk space`, { usage: size });
+            moduleLogger.info(`warp 10 using ${formatDiskSize(size)} of disk space`, { leveldbBytes, datalogBytes });
 
             const shouldLock = this._checkHardLimit(size, this.nodeId);
             if (shouldLock) {

--- a/libV2/tasks/DiskUsage.js
+++ b/libV2/tasks/DiskUsage.js
@@ -1,4 +1,6 @@
 const async = require('async');
+const Path = require('path');
+const fs = require('fs');
 const promClient = require('prom-client');
 const BaseTask = require('./BaseTask');
 const config = require('../config');
@@ -55,9 +57,15 @@ class MonitorDiskUsage extends BaseTask {
             labelNames: ['origin', 'containerName'],
         });
 
-        const diskUsage = new promClient.Gauge({
-            name: 'utapi_monitor_disk_usage_bytes',
-            help: 'Total bytes used by warp 10',
+        const leveldbBytes = new promClient.Gauge({
+            name: 'utapi_monitor_disk_usage_leveldb_bytes',
+            help: 'Total bytes used by warp 10 leveldb',
+            labelNames: ['origin', 'containerName'],
+        });
+
+        const datalogBytes = new promClient.Gauge({
+            name: 'utapi_monitor_disk_usage_datalog_bytes',
+            help: 'Total bytes used by warp 10 datalog',
             labelNames: ['origin', 'containerName'],
         });
 
@@ -75,7 +83,8 @@ class MonitorDiskUsage extends BaseTask {
 
         return {
             isLocked,
-            diskUsage,
+            leveldbBytes,
+            datalogBytes,
             hardLimitRatio,
             hardLimitSetting,
         };
@@ -85,7 +94,8 @@ class MonitorDiskUsage extends BaseTask {
      * Metrics for MonitorDiskUsage
      * @typedef {Object} MonitorDiskUsageMetrics
      * @property {boolean} isLocked - Indicates if writes have been disabled for the monitored warp10
-     * @property {number} diskUsage - Total bytes used by warp 10
+     * @property {number} leveldbBytes - Total bytes used by warp 10 leveldb
+     * @property {number} datalogBytes - Total bytes used by warp 10 datalog
      * @property {number} hardLimitRatio - Percent of the hard limit used by warp 10
      * @property {number} hardLimitSetting - The hard limit setting in bytes
      */
@@ -104,8 +114,12 @@ class MonitorDiskUsage extends BaseTask {
             this._metricsHandlers.isLocked.set(metrics.isLocked ? 1 : 0);
         }
 
-        if (metrics.diskUsage !== undefined) {
-            this._metricsHandlers.diskUsage.set(metrics.diskUsage);
+        if (metrics.leveldbBytes !== undefined) {
+            this._metricsHandlers.leveldbBytes.set(metrics.leveldbBytes);
+        }
+
+        if (metrics.datalogBytes !== undefined) {
+            this._metricsHandlers.datalogBytes.set(metrics.datalogBytes);
         }
 
         if (metrics.hardLimitRatio !== undefined) {
@@ -129,9 +143,13 @@ class MonitorDiskUsage extends BaseTask {
         return this._program.lock !== undefined;
     }
 
-    _getUsage() {
-        moduleLogger.debug(`calculating disk usage for ${this._path}`);
-        return getFolderSize(this._path);
+    // eslint-disable-next-line class-methods-use-this
+    async _getUsage(path) {
+        moduleLogger.debug(`calculating disk usage for ${path}`);
+        if (!fs.existsSync(path)) {
+            throw Error(`failed to calculate usage for non-existent path ${path}`);
+        }
+        return getFolderSize(path);
     }
 
     async _expireMetrics(timestamp) {
@@ -249,16 +267,19 @@ class MonitorDiskUsage extends BaseTask {
             return;
         }
 
-        let size = null;
+        let leveldbBytes = null;
+        let datalogBytes = null;
         try {
-            size = await this._getUsage();
+            leveldbBytes = await this._getUsage(Path.join(this._path, 'leveldb'));
+            datalogBytes = await this._getUsage(Path.join(this._path, 'datalog'));
         } catch (error) {
             moduleLogger.error(`error calculating disk usage for ${this._path}`, { error });
             return;
         }
 
-        this._pushMetrics({ diskUsage: size });
+        this._pushMetrics({ leveldbBytes, datalogBytes });
 
+        const size = leveldbBytes + datalogBytes;
         if (this._hardLimit !== null) {
             moduleLogger.info(`warp 10 leveldb using ${formatDiskSize(size)} of disk space`, { usage: size });
 

--- a/tests/functional/v2/task/testDiskUsage.js
+++ b/tests/functional/v2/task/testDiskUsage.js
@@ -74,7 +74,7 @@ describe('Test MonitorDiskUsage', () => {
             });
     });
 
-    it('should fail if a subpath does not exists', () => {
+    it('should fail if a subpath does not exist', () => {
         assert.doesNotThrow(() => task._execute());
         assert.strictEqual(task.usage, undefined);
     });

--- a/tests/functional/v2/task/testDiskUsage.js
+++ b/tests/functional/v2/task/testDiskUsage.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const fs = require('fs');
 const promClient = require('prom-client');
 const uuid = require('uuid');
 
@@ -9,9 +10,10 @@ const { fillDir } = require('../../../utils/v2Data');
 const { assertMetricValue } = require('../../../utils/prom');
 
 class MonitorDiskUsageShim extends MonitorDiskUsage {
-    async _getUsage() {
-        this.usage = await super._getUsage();
-        return this.usage;
+    async _getUsage(path) {
+        const usage = await super._getUsage(path);
+        this.usage = (this.usage || 0) + usage;
+        return usage;
     }
 }
 
@@ -45,6 +47,7 @@ describe('Test MonitorDiskUsage', () => {
 
     beforeEach(async () => {
         path = `/tmp/diskusage-${uuid.v4()}`;
+        fs.mkdirSync(path);
         task = new MonitorDiskUsageShim({ warp10: [], enableMetrics: true });
         task._path = path;
         task._enabled = true;
@@ -56,12 +59,23 @@ describe('Test MonitorDiskUsage', () => {
         promClient.register.clear();
     });
 
-    testCases.map(testCase =>
+    testCases.map(testCase => {
         it(`should calculate disk usage for ${testCase.count} files of ${testCase.size} bytes each`,
             async () => {
-                fillDir(path, testCase);
+                fillDir(`${path}/leveldb`, testCase);
+                fillDir(`${path}/datalog`, testCase);
                 await task._execute();
-                assert.strictEqual(task.usage, testCase.expected + emptyDirSize + (emptyFileSize * testCase.count));
-                await assertMetricValue('utapi_monitor_disk_usage_bytes', task.usage);
-            }));
+                const expectedSingleSize = emptyDirSize + testCase.expected + (emptyFileSize * testCase.count);
+                const expectedTotalSize = expectedSingleSize * 2;
+                assert.strictEqual(task.usage, expectedTotalSize);
+                // Should equal the usage minus the empty datalog
+                await assertMetricValue('utapi_monitor_disk_usage_leveldb_bytes', expectedSingleSize);
+                await assertMetricValue('utapi_monitor_disk_usage_datalog_bytes', expectedSingleSize);
+            });
+    });
+
+    it('should fail if a subpath does not exists', () => {
+        assert.doesNotThrow(() => task._execute());
+        assert.strictEqual(task.usage, undefined);
+    });
 });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1251.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/feature/UTAPI-76/breakout_leveldb_and_datalog`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/feature/UTAPI-76/breakout_leveldb_and_datalog
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/feature/UTAPI-76/breakout_leveldb_and_datalog
```

Please always comment pull request #1251 instead of this one.