### PR TITLE
Improvement/utapi 103/support reindex by account

### DIFF
--- a/lib/reindex/s3_bucketd.py
+++ b/lib/reindex/s3_bucketd.py
@@ -168,6 +168,14 @@ class BucketDClient:
             _log.error('Unhandled exception getting bucket attributes bucket:%s'%name)
             raise
 
+    def get_bucket_md(self, name):
+        md = self._get_bucket_attributes(name)
+        canonId = md.get('owner')
+        if canonId is None:
+            _log.error('No owner found for bucket %s'%name)
+            raise InvalidListing(name)
+        return Bucket(canonId, name, md.get('objectLockEnabled', False))
+
     def list_buckets(self, name = None):
 
         def get_next_marker(p):

--- a/lib/reindex/s3_bucketd.py
+++ b/lib/reindex/s3_bucketd.py
@@ -63,6 +63,10 @@ class InvalidListing(Exception):
     def __init__(self, bucket):
         super().__init__('Invalid contents found while listing bucket %s'%bucket)
 
+class BucketNotFound(Exception):
+    def __init__(self, bucket):
+        super().__init__('Bucket %s not found'%bucket)
+
 class BucketDClient:
 
     '''Performs Listing calls against bucketd'''
@@ -151,7 +155,7 @@ class BucketDClient:
                 return resp.json()
             else:
                 _log.error('Error getting bucket attributes bucket:%s status_code:%s'%(name, resp.status_code))
-                raise InvalidListing(name)
+                raise BucketNotFound(name)
         except ValueError as e:
             _log.exception(e)
             _log.error('Invalid attributes response body! bucket:%s'%name)

--- a/lib/reindex/s3_bucketd.py
+++ b/lib/reindex/s3_bucketd.py
@@ -1,5 +1,6 @@
 import argparse
 import concurrent.futures as futures
+import functools
 import itertools
 import json
 import logging
@@ -141,6 +142,7 @@ class BucketDClient:
             else:
                 is_truncated = len(payload) > 0
 
+    @functools.lru_cache(maxsize=16)
     def _get_bucket_attributes(self, name):
         url = self.__url_attribute_format.format(addr=self._bucketd_addr, bucket=name)
         try:

--- a/lib/reindex/s3_bucketd.py
+++ b/lib/reindex/s3_bucketd.py
@@ -296,7 +296,7 @@ class BucketDClient:
                 total_size += size
 
         except InvalidListing:
-            _log.error('Invalid contents in listing. bucket:%s status_code:%s'%(bucket.name, status_code))
+            _log.error('Invalid contents in listing. bucket:%s'%bucket.name)
             raise InvalidListing(bucket.name)
         return count, total_size
 


### PR DESCRIPTION
This PR adds support for limiting reindex to particular account(s).
As part of the changes, rather than having `--bucket` and `--account` differ in behavior, and to have a more consistent CLI, I've pulled in some of the requested features from S3C-8077 (support multiple buckets).
I also added a `--dry-run` flag to skip redis updates to help both dev and field use.

Modifies:
`--bucket`: Can now be passed multiple times to reindex multiple buckets

Adds:
`--account`: Limit reindex to an account canonical Id. Can be passed multiple times.
`--account-file`: Read canonical Ids from a file. 1 per line.
`--bucket-file`: Read bucket names from a file. 1 per line.
`--dry-run`: Skip updating redis.
