### PR TITLE
bugfix: Fix permissions on warp10 release workflow

### DIFF
--- a/.github/workflows/release-warp10.yaml
+++ b/.github/workflows/release-warp10.yaml
@@ -15,13 +15,15 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
+      packages: write
     uses: scality/workflows/.github/workflows/docker-build.yaml@v2
-    secrets: inherit
     with:
       name: warp10
       context: .
       file: images/warp10/Dockerfile
-      tag: ${{ github.event.inputs.tag }}
+      tag: ${{ inputs.tag }}
       lfs: true
 
   release:
@@ -29,11 +31,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: softprops/action-gh-release@v2
+      - name: Create Github Release for Warp10
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           name: Release utapi/warp10:${{ github.event.inputs.tag }}-warp10
-          tag_name: ${{ github.event.inputs.tag }}-warp10
-          generate_release_notes: false
           target_commitish: ${{ github.sha }}
+          tag_name: ${{ inputs.tag }}-warp10
+          generate_release_notes: false


### PR DESCRIPTION
Issue: UTAPI-108

Added permissions for github release workflow.
Sample release: https://github.com/scality/utapi/pkgs/container/utapi%2Fwarp10/274300640?tag=7.10.11-PW.1