### PR TITLE
UTAPI-110 outdated CI runner OS

### DIFF
--- a/.github/workflows/build-ci.yaml
+++ b/.github/workflows/build-ci.yaml
@@ -39,7 +39,7 @@ jobs:
         REDIS_IMAGE=ghcr.io/${{ github.repository }}/redis-ci:${{ github.sha }}
 
   vault-ci:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Update the CI runner to `ubuntu-22.04` as `ubuntu-20.04` is no longer supported.