### PR TITLE
UTAPI-116: Add input tag into release run name

### DIFF
--- a/.github/workflows/release-warp10.yaml
+++ b/.github/workflows/release-warp10.yaml
@@ -1,4 +1,5 @@
 name: release-warp10
+run-name: release ${{ inputs.tag }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,5 @@
 name: release
+run-name: release ${{ inputs.tag }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Like it's done in other repo like cloudserver to easily see the action run