### PR TITLE
bf(UTAPI-119): Stop _pushMetricDeleteMarker from clearing storageUtilized of current time segment

### DIFF
--- a/lib/UtapiClient.js
+++ b/lib/UtapiClient.js
@@ -592,33 +592,27 @@ class UtapiClient {
                      * on the number of objects.
                      */
                     actionCounter -= 1;
-                }
-
-                const key = generateStateKey(p, 'numberOfObjects');
-
-                const byteArr = results[index + commandsGroupSize - 1][1];
-                const oldByteLength = byteArr ? parseInt(byteArr[0], 10) : 0;
-                const newByteLength = member.serialize(Math.max(0, oldByteLength - params.byteLength));
-
-                cmds2.push(
-                    ['zremrangebyscore', key, timestamp, timestamp],
-                    ['zadd', key, timestamp, member.serialize(actionCounter)],
-
-                );
-
-                if (Number.isInteger(params.byteLength)) {
                     cmds2.push(
                         ['decr', generateCounter(p, 'numberOfObjectsCounter')],
                         ['decrby', generateCounter(p, 'storageUtilizedCounter'), params.byteLength],
                     );
+
+                    const byteArr = results[index + commandsGroupSize - 1][1];
+                    if (byteArr) {
+                        const oldByteLength = parseInt(byteArr[0], 10);
+                        const newByteLength = member.serialize(Math.max(0, oldByteLength - params.byteLength));
+                        cmds2.push(
+                            ['zremrangebyscore', generateStateKey(p, 'storageUtilized'), timestamp, timestamp],
+                            ['zadd', generateStateKey(p, 'storageUtilized'), timestamp, newByteLength],
+                        );
+                    }
                 }
 
-                if (byteArr) {
-                    cmds2.push(
-                        ['zremrangebyscore', generateStateKey(p, 'storageUtilized'), timestamp, timestamp],
-                        ['zadd', generateStateKey(p, 'storageUtilized'), timestamp, newByteLength],
-                    );
-                }
+                const key = generateStateKey(p, 'numberOfObjects');
+                cmds2.push(
+                    ['zremrangebyscore', key, timestamp, timestamp],
+                    ['zadd', key, timestamp, member.serialize(actionCounter)],
+                );
 
                 return true;
             });

--- a/tests/unit/testUtapiClient.js
+++ b/tests/unit/testUtapiClient.js
@@ -694,6 +694,7 @@ tests.forEach(test => {
             const expected = buildExpectedResult({
                 action: 'DeleteObject',
                 numberOfObjects: '1',
+                storageUtilized: '0',
             });
             testMetric('putDeleteMarkerObject', metricTypes, expected, done);
         });
@@ -702,6 +703,7 @@ tests.forEach(test => {
             const expected = buildExpectedResult({
                 action: 'PutObject',
                 numberOfObjects: '1',
+                storageUtilized: '258',
             });
             const metrics = {
                 bucket: '5741-repro',
@@ -717,11 +719,48 @@ tests.forEach(test => {
                 const expected = buildExpectedResult({
                     action: 'DeleteObject',
                     numberOfObjects: '1',
+                    storageUtilized: '0',
                 });
                 const metrics2 = {
                     bucket: '5741-repro',
                     keys: ['foo2'],
                     byteLength: 258,
+                    newByteLength: undefined,
+                    oldByteLength: undefined,
+                    numberOfObjects: undefined,
+                    accountId: '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be',
+                    userId: undefined,
+                };
+                testMetric('putDeleteMarkerObject', Object.assign(metrics2, metricTypes), expected, done);
+            });
+        });
+
+        it('should push putDeleteMarkerObject metrics and have correct bytes and number of objects', done => {
+            const expected = buildExpectedResult({
+                action: 'PutObject',
+                numberOfObjects: '1',
+                storageUtilized: '258',
+            });
+            const metrics = {
+                bucket: '10699-repro',
+                keys: ['foo2'],
+                byteLength: undefined,
+                newByteLength: 258,
+                oldByteLength: null,
+                numberOfObjects: 1,
+                accountId: '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be',
+                userId: undefined,
+            };
+            testMetric('putObject', Object.assign(metrics, metricTypes), expected, () => {
+                const expected = buildExpectedResult({
+                    action: 'DeleteObject',
+                    numberOfObjects: '2',
+                    storageUtilized: '258',
+                });
+                const metrics2 = {
+                    bucket: '10699-repro',
+                    keys: ['foo2'],
+                    byteLength: undefined,
                     newByteLength: undefined,
                     oldByteLength: undefined,
                     numberOfObjects: undefined,


### PR DESCRIPTION
If `params.byteLength` is not an integer and `byteArr` is truthy then `newByteLength` would be calculated as `NaN`.
This happens when replicating a delete marker, and likely in other cases as well.
