### PR TITLE
UTAPI-121 Update GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/workflows/build-ci.yaml
+++ b/.github/workflows/build-ci.yaml
@@ -42,21 +42,21 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           lfs: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to GitHub Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ github.token }}
 
       - name: Build and push vault Image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: .github/docker/vault

--- a/.github/workflows/release-warp10.yaml
+++ b/.github/workflows/release-warp10.yaml
@@ -33,7 +33,7 @@ jobs:
     needs: build
     steps:
       - name: Create Github Release for Warp10
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-22.04-2core
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         lfs: true
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: '22.11.0'
         cache: yarn
@@ -124,14 +124,14 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         lfs: true
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: '22.11.0'
         cache: yarn
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.9'
         cache: pip
@@ -218,14 +218,14 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         lfs: true
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: '22.11.0'
         cache: yarn
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.9'
         cache: pip
@@ -345,14 +345,14 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         lfs: true
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: '22.11.0'
         cache: yarn
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.9'
         cache: pip


### PR DESCRIPTION
## Summary
Update GitHub Actions workflow files to use action versions running on Node 24.

Closes UTAPI-121

## Context
GitHub is deprecating Node 20 as the JavaScript runtime for GitHub Actions runners:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Timeline:
- June 2, 2026: Runners default to Node 24 (deprecation warnings)
- Fall 2026: Node 20 completely removed

## Changes
Updated action versions across workflow files to Node 24-compatible versions:
- `actions/checkout@v4` → `@v6`
- `actions/setup-node@v4` → `@v6`
- `docker/build-push-action@v5` → `@v7`
- `docker/login-action@v3` → `@v4`
- `docker/setup-buildx-action@v3` → `@v4`
- `codecov/codecov-action@v4/@v5` → `@v6`
- `softprops/action-gh-release@v2` → `@v3`